### PR TITLE
Added a method to remove similar points up to a given absolute tolerance

### DIFF
--- a/tests/test_base/test_remove_identical_points.py
+++ b/tests/test_base/test_remove_identical_points.py
@@ -38,3 +38,22 @@ def test_identical_points():
     assert pytest.approx(d.X) == expected_X
     assert pytest.approx(d.dist_indices) == expected_dist_indices
     assert pytest.approx(d.distances) == expected_dists
+
+
+def test_similar_points():
+    """Test the removal of similar points."""
+    X = np.array([[2, 1, 3], [1, 2, 3], [1, 2, 3.1]])
+
+    d = Base(X, verbose=True)
+
+    d.compute_distances()
+
+    d.remove_similar_points(atol=0.2)
+
+    expected_X = np.array([[2, 1, 3], [1, 2, 3]])
+    expected_dist_indices = np.array([[0, 1], [1, 0]])
+    expected_dists = np.array([[0.0, 1.4142135623730951], [0.0, 1.4142135623730951]])
+
+    assert pytest.approx(d.X) == expected_X
+    assert pytest.approx(d.dist_indices) == expected_dist_indices
+    assert pytest.approx(d.distances) == expected_dists


### PR DESCRIPTION
## Proposed changes

As discussed with @imacocco I added a simple method to check for duplicate up to a given `atol` distance.

The method loops in order over all points, and removes points at distance below threshold from each.

If a given point "i" has not been removed, but all its neighbours below tolerance have been already removed, then "i" is also removed since presumably there is another point "j" that is very close to the neighbours of "i" but did not have "i" in its neighbours.

The "transitivity" property described above is only strictly valid for zero distances.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
