### PR TITLE
add warning for datasets with overlapping datapoints

### DIFF
--- a/dadapy/_utils/utils.py
+++ b/dadapy/_utils/utils.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-import warnings
 import multiprocessing
 import re
+import warnings
 
 import numpy as np
 import scipy.special as sp

--- a/dadapy/_utils/utils.py
+++ b/dadapy/_utils/utils.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-
+import warnings
 import multiprocessing
 import re
 
@@ -144,6 +144,11 @@ def compute_nn_distances(X, maxk, metric="euclidean", period=None):
     distances, dist_indices = compute_cross_nn_distances(
         X, X, maxk + 1, metric=metric, period=period
     )
+
+    zero_dists = np.sum(distances[:, 1]<=1.1*np.finfo(distances.dtype).eps)
+    if zero_dists > 0:
+        warnings.warn(f'there may be data with zero distance from each other; this may compromise the correct behavior of some routines')
+
     return distances, dist_indices
 
 

--- a/dadapy/_utils/utils.py
+++ b/dadapy/_utils/utils.py
@@ -145,9 +145,11 @@ def compute_nn_distances(X, maxk, metric="euclidean", period=None):
         X, X, maxk + 1, metric=metric, period=period
     )
 
-    zero_dists = np.sum(distances[:, 1]<=1.1*np.finfo(distances.dtype).eps)
+    zero_dists = np.sum(distances[:, 1] <= 1.1 * np.finfo(distances.dtype).eps)
     if zero_dists > 0:
-        warnings.warn(f'there may be data with zero distance from each other; this may compromise the correct behavior of some routines')
+        warnings.warn(
+            f"there may be data with zero distance from each other; this may compromise the correct behavior of some routines"
+        )
 
     return distances, dist_indices
 

--- a/dadapy/base.py
+++ b/dadapy/base.py
@@ -18,7 +18,6 @@ The *base* module contains the *Base* class.
 
 This class contains essential methods and attributes needed for all other classes.
 """
-
 import multiprocessing
 import time
 

--- a/dadapy/id_estimation.py
+++ b/dadapy/id_estimation.py
@@ -18,7 +18,7 @@ The *id_estimation* module contains the *IdEstimation* class.
 
 The different algorithms of intrinsic dimension estimation are implemented as methods of this class.
 """
-
+import warnings
 import copy
 import math
 import multiprocessing
@@ -400,6 +400,7 @@ class IdEstimation(Base):
         dist = copy.deepcopy(dist[:, : self.maxk + 1])
         neigh_ind = copy.deepcopy(neigh_ind[:, : self.maxk + 1])
 
+
         return dist, neigh_ind, mus, rs
 
     def _return_mus_scaling(self, range_scaling):
@@ -439,6 +440,10 @@ class IdEstimation(Base):
         )
 
         neigh_dist, neigh_ind, mus, rs = zip(*chunked_results)
+
+        zero_dists = np.sum(neigh_dist[0][:, 1]<=1.1*np.finfo(neigh_dist[0].dtype).eps)
+        if zero_dists > 0:
+            warnings.warn(f'there may be data with zero distance from each other; this may compromise the correct behavior of some routines')
 
         return (
             np.vstack(neigh_dist),

--- a/dadapy/id_estimation.py
+++ b/dadapy/id_estimation.py
@@ -400,7 +400,6 @@ class IdEstimation(Base):
         dist = copy.deepcopy(dist[:, : self.maxk + 1])
         neigh_ind = copy.deepcopy(neigh_ind[:, : self.maxk + 1])
 
-
         return dist, neigh_ind, mus, rs
 
     def _return_mus_scaling(self, range_scaling):
@@ -441,9 +440,14 @@ class IdEstimation(Base):
 
         neigh_dist, neigh_ind, mus, rs = zip(*chunked_results)
 
-        zero_dists = np.sum(neigh_dist[0][:, 1]<=1.1*np.finfo(neigh_dist[0].dtype).eps)
+        zero_dists = np.sum(
+            neigh_dist[0][:, 1] <= 1.1 * np.finfo(neigh_dist[0].dtype).eps
+        )
         if zero_dists > 0:
-            warnings.warn(f'there may be data with zero distance from each other; this may compromise the correct behavior of some routines')
+            warnings.warn(
+                """there may be data with zero distance from each other;
+                this may compromise the correct behavior of some routines"""
+            )
 
         return (
             np.vstack(neigh_dist),

--- a/dadapy/id_estimation.py
+++ b/dadapy/id_estimation.py
@@ -18,10 +18,10 @@ The *id_estimation* module contains the *IdEstimation* class.
 
 The different algorithms of intrinsic dimension estimation are implemented as methods of this class.
 """
-import warnings
 import copy
 import math
 import multiprocessing
+import warnings
 from functools import partial
 
 import numpy as np

--- a/tests/test_density_estimation/test_interpolators.py
+++ b/tests/test_density_estimation/test_interpolators.py
@@ -18,6 +18,7 @@
 import os
 
 import numpy as np
+import pytest
 
 from dadapy import DensityEstimation
 
@@ -41,4 +42,3 @@ def test_density_estimation_kNN():
     expected_diff = np.array([np.log(k) - np.log(k - 1)] * len(diff))
 
     assert diff == pytest.approx(expected_diff, abs=1e-6)
-    #assert (diff == expected_diff).all()

--- a/tests/test_density_estimation/test_interpolators.py
+++ b/tests/test_density_estimation/test_interpolators.py
@@ -40,4 +40,5 @@ def test_density_estimation_kNN():
 
     expected_diff = np.array([np.log(k) - np.log(k - 1)] * len(diff))
 
-    assert (diff == expected_diff).all()
+    assert diff == pytest.approx(expected_diff, abs=1e-6)
+    #assert (diff == expected_diff).all()

--- a/tests/test_id_estimation/test_gride.py
+++ b/tests/test_id_estimation/test_gride.py
@@ -48,6 +48,7 @@ def test_compute_id_gride():
 
 
 def test_zero_dist():
+    """Test that a warning message appear if there are overlapping datapoints."""
     X = np.array([[0, 0, 0], [0, 0, 0], [0.9, 0, 0]])
     de = IdEstimation(coordinates=X)
 

--- a/tests/test_id_estimation/test_gride.py
+++ b/tests/test_id_estimation/test_gride.py
@@ -45,3 +45,10 @@ def test_compute_id_gride():
     assert rs == pytest.approx(
         [0.39476585, 0.56740507, 0.80139545, 1.13457408, 1.64776878], abs=0.01
     )
+
+def test_zero_dist():
+    X = np.array([[0, 0, 0], [0, 0, 0], [0.9, 0, 0]])
+    de = IdEstimation(coordinates=X)
+
+    with pytest.warns(UserWarning):
+        de.return_id_scaling_gride()

--- a/tests/test_id_estimation/test_gride.py
+++ b/tests/test_id_estimation/test_gride.py
@@ -46,6 +46,7 @@ def test_compute_id_gride():
         [0.39476585, 0.56740507, 0.80139545, 1.13457408, 1.64776878], abs=0.01
     )
 
+
 def test_zero_dist():
     X = np.array([[0, 0, 0], [0, 0, 0], [0.9, 0, 0]])
     de = IdEstimation(coordinates=X)

--- a/tests/test_utils/test_distances_utils.py
+++ b/tests/test_utils/test_distances_utils.py
@@ -2,7 +2,8 @@ from dadapy._utils import utils
 import numpy as np
 import pytest
 
+
 def test_zero_dist():
-    X = np.array([[0., 0., 0.], [0., 0., 0.], [0.9, 0., 0.]])
+    X = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.9, 0.0, 0.0]])
     with pytest.warns(UserWarning):
         utils.compute_nn_distances(X, maxk=2, metric="euclidean", period=None)

--- a/tests/test_utils/test_distances_utils.py
+++ b/tests/test_utils/test_distances_utils.py
@@ -1,6 +1,7 @@
-from dadapy._utils import utils
 import numpy as np
 import pytest
+
+from dadapy._utils import utils
 
 
 def test_zero_dist():

--- a/tests/test_utils/test_distances_utils.py
+++ b/tests/test_utils/test_distances_utils.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-"""Module for testing utils functions"""
+"""Module for testing utils functions."""
 
 
 import numpy as np

--- a/tests/test_utils/test_distances_utils.py
+++ b/tests/test_utils/test_distances_utils.py
@@ -1,3 +1,21 @@
+# Copyright 2021-2022 The DADApy Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Module for testing utils functions"""
+
+
 import numpy as np
 import pytest
 
@@ -5,6 +23,7 @@ from dadapy._utils import utils
 
 
 def test_zero_dist():
+    """Test that a warning message appear if there are overlapping datapoints."""
     X = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.9, 0.0, 0.0]])
     with pytest.warns(UserWarning):
         utils.compute_nn_distances(X, maxk=2, metric="euclidean", period=None)

--- a/tests/test_utils/test_distances_utils.py
+++ b/tests/test_utils/test_distances_utils.py
@@ -1,0 +1,8 @@
+from dadapy._utils import utils
+import numpy as np
+import pytest
+
+def test_zero_dist():
+    X = np.array([[0., 0., 0.], [0., 0., 0.], [0.9, 0., 0.]])
+    with pytest.warns(UserWarning):
+        utils.compute_nn_distances(X, maxk=2, metric="euclidean", period=None)


### PR DESCRIPTION
added explicit warnings (and relative pytest files) to the distance matrices computed in  'compute_nn_distances' and 'return_id_gride' when distances of nearby points is close to zero (<=1.1 eps). This warning does not stop the normal workflow.