### PR TITLE
'divide by zero' in return_not_normalised_density_PAk

### DIFF
--- a/dadapy/_utils/density_estimation.py
+++ b/dadapy/_utils/density_estimation.py
@@ -94,9 +94,12 @@ def return_not_normalised_density_PAk(
 
             r = distances[i, j]
             r1 = distances[i, j + 1]
+            if np.abs(r1-r) < np.finfo(r.dtype).resolution:
+                r1+= 10*np.finfo(r.dtype).resolution
             exponent = intrinsic_dim * np.log(r1) + np.log(
                 1 - (r / r1) ** intrinsic_dim
             )
+
             vi[j] = prefactor * np.exp(exponent)
 
             if vi[j] < 1.0e-300:

--- a/dadapy/_utils/density_estimation.py
+++ b/dadapy/_utils/density_estimation.py
@@ -94,8 +94,8 @@ def return_not_normalised_density_PAk(
 
             r = distances[i, j]
             r1 = distances[i, j + 1]
-            if np.abs(r1-r) < np.finfo(r.dtype).resolution:
-                r1+= 10*np.finfo(r.dtype).resolution
+            if np.abs(r1 - r) < np.finfo(r.dtype).resolution:
+                r1 += 10 * np.finfo(r.dtype).resolution
             exponent = intrinsic_dim * np.log(r1) + np.log(
                 1 - (r / r1) ** intrinsic_dim
             )


### PR DESCRIPTION
If two points are equidistant to a given 'pivot' the volume of the shell is zero and this may cause some errors in the actual implementation of the volume in pak.

If would either restore the original implementation or add the check I propose to avoid 'divide by zero' errors when r==r1 in
 np.log( 1 - (r / r1) ** intrinsic_dim)