### PR TITLE
Fixed cross NN with periodic box and added tests.

### DIFF
--- a/dadapy/_utils/utils.py
+++ b/dadapy/_utils/utils.py
@@ -121,7 +121,8 @@ def compute_cross_nn_distances(X_new, X, maxk, metric="euclidean", period=None):
                 "periodic distance computation is supported only for euclidean and manhattan metrics"
             )
 
-        distances, dist_indices = compute_NN_PBC(X, maxk, box_size=period, p=p)
+        tree = cKDTree(X, boxsize=period)
+        distances, dist_indices = tree.query(X_new, k=maxk, p=p)
 
     return distances, dist_indices
 

--- a/tests/test_utils/test_distances_utils.py
+++ b/tests/test_utils/test_distances_utils.py
@@ -28,21 +28,23 @@ def test_zero_dist():
     with pytest.warns(UserWarning):
         utils.compute_nn_distances(X, maxk=2, metric="euclidean", period=None)
 
+
 def test_cross_nn_distances():
     """Test for computation of cross nearest neighbour distances."""
     X = np.array([0, 0.1, 0.3, 0.55]).reshape(-1, 1)
     X_new = np.array([0.1, 0.9]).reshape(-1, 1)
     maxk = 3
 
-    expected_indices = [[1, 0, 2],
-                        [3, 2, 1]]
-    expected_distances = [[0, 0.1, 0.2],
-                          [0.35, 0.6, 0.8]]
+    expected_indices = [[1, 0, 2], [3, 2, 1]]
+    expected_distances = [[0, 0.1, 0.2], [0.35, 0.6, 0.8]]
 
-    distances, indices = utils.compute_cross_nn_distances(X_new, X, maxk, metric="euclidean")
+    distances, indices = utils.compute_cross_nn_distances(
+        X_new, X, maxk, metric="euclidean"
+    )
 
     assert pytest.approx(indices) == expected_indices
     assert pytest.approx(distances) == expected_distances
+
 
 def test_cross_nn_distances_periodic():
     """Test for computation of cross nearest neighbour distances for periodic boundaries."""
@@ -50,13 +52,12 @@ def test_cross_nn_distances_periodic():
     X_new = np.array([0.1, 0.9]).reshape(-1, 1)
     maxk = 3
 
-    expected_indices = [[1, 0, 2],
-                        [0, 1, 3]]
-    expected_distances = [[0, 0.1, 0.2],
-                          [0.1, 0.2, 0.35]]
+    expected_indices = [[1, 0, 2], [0, 1, 3]]
+    expected_distances = [[0, 0.1, 0.2], [0.1, 0.2, 0.35]]
 
-    distances, indices = utils.compute_cross_nn_distances(X_new, X, maxk, metric="euclidean", period=1)
+    distances, indices = utils.compute_cross_nn_distances(
+        X_new, X, maxk, metric="euclidean", period=1
+    )
 
     assert pytest.approx(indices) == expected_indices
     assert pytest.approx(distances) == expected_distances
-

--- a/tests/test_utils/test_distances_utils.py
+++ b/tests/test_utils/test_distances_utils.py
@@ -27,3 +27,36 @@ def test_zero_dist():
     X = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.9, 0.0, 0.0]])
     with pytest.warns(UserWarning):
         utils.compute_nn_distances(X, maxk=2, metric="euclidean", period=None)
+
+def test_cross_nn_distances():
+    """Test for computation of cross nearest neighbour distances."""
+    X = np.array([0, 0.1, 0.3, 0.55]).reshape(-1, 1)
+    X_new = np.array([0.1, 0.9]).reshape(-1, 1)
+    maxk = 3
+
+    expected_indices = [[1, 0, 2],
+                        [3, 2, 1]]
+    expected_distances = [[0, 0.1, 0.2],
+                          [0.35, 0.6, 0.8]]
+
+    distances, indices = utils.compute_cross_nn_distances(X_new, X, maxk, metric="euclidean")
+
+    assert pytest.approx(indices) == expected_indices
+    assert pytest.approx(distances) == expected_distances
+
+def test_cross_nn_distances_periodic():
+    """Test for computation of cross nearest neighbour distances for periodic boundaries."""
+    X = np.array([0, 0.1, 0.3, 0.55]).reshape(-1, 1)
+    X_new = np.array([0.1, 0.9]).reshape(-1, 1)
+    maxk = 3
+
+    expected_indices = [[1, 0, 2],
+                        [0, 1, 3]]
+    expected_distances = [[0, 0.1, 0.2],
+                          [0.1, 0.2, 0.35]]
+
+    distances, indices = utils.compute_cross_nn_distances(X_new, X, maxk, metric="euclidean", period=1)
+
+    assert pytest.approx(indices) == expected_indices
+    assert pytest.approx(distances) == expected_distances
+


### PR DESCRIPTION
## Proposed changes

Correction of a bug in `utils.compute_cross_nn_distances`. When using periodic conditions the function computed the self NN distances of dataset `X` with `compute_NN_PBC` instead of cross NN distances between `X_new` and `X`. 
This affected interpolated density estimation.

## Types of changes

The cross NN distance is directly computed using `cKDTree` instead of calling `compute_NN_PBC`.
I have added two tests in `test_distances_utils`, `test_cross_nn_distances` and `test_cross_nn_distances_periodic`.