### PR TITLE
fix warnings related to float64-32 conversion

### DIFF
--- a/dadapy/_utils/utils.py
+++ b/dadapy/_utils/utils.py
@@ -146,7 +146,7 @@ def compute_nn_distances(X, maxk, metric="euclidean", period=None):
         X, X, maxk + 1, metric=metric, period=period
     )
 
-    zero_dists = np.sum(distances[:, 1:] <= 1.1 * np.finfo(distances.dtype).eps)
+    zero_dists = np.sum(distances[:, 1:] <= 1.01 * np.finfo(np.float32).eps)
     if zero_dists > 0:
         warnings.warn(
             f"There are points with neighbours at 0 distance, meaning the dataset probably has identical points.\n"

--- a/dadapy/base.py
+++ b/dadapy/base.py
@@ -66,7 +66,7 @@ class Base:
             assert isinstance(
                 self.X, np.ndarray
             ), "Coordinates must be in numpy ndarray format"
-            if  self.X.dtype == np.float64:
+            if self.X.dtype == np.float64:
                 pass
             elif self.X.dtype == np.float32 or self.X.dtype == np.float16:
                 self.X = self.X.astype(np.float64, casting="safe")

--- a/dadapy/base.py
+++ b/dadapy/base.py
@@ -66,7 +66,9 @@ class Base:
             assert isinstance(
                 self.X, np.ndarray
             ), "Coordinates must be in numpy ndarray format"
-            if self.X.dtype == np.float32 or self.X.dtype == np.float16:
+            if  self.X.dtype == np.float64:
+                pass
+            elif self.X.dtype == np.float32 or self.X.dtype == np.float16:
                 self.X = self.X.astype(np.float64, casting="safe")
             else:
                 warnings.warn(


### PR DESCRIPTION
## Proposed changes

I fix two warnings. 

The first appeared when a coordinate matrix of type float64 is passed to the Data constructor. 

The second appeared as a consequence of the fact that the distance computation probably casts data to float32, and hence the correct precision to check for equal distances is the float32.
