### PR TITLE
Refactor overlap functions and add new test envs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,11 +17,11 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-python@master
         with:
-          python-version: 3.12
+          python-version: 3.11
       - name: Install dependencies
         run: |
           pip install -e ."[dev]"
 
       - name: Notebook tests
         run: |
-          tox -e py3.12-nb
+          tox -e py3.11-nb

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,11 +17,11 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-python@master
         with:
-          python-version: 3.8
+          python-version: 3.12
       - name: Install dependencies
         run: |
           pip install -e ."[dev]"
 
       - name: Notebook tests
         run: |
-          tox -e py3.8-nb
+          tox -e py3.12-nb

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.12]
+        python-version: [3.11]
 
     timeout-minutes: 30
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8]
+        python-version: [3.12]
 
     timeout-minutes: 30
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,14 +14,21 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest] # TODO: add macos-latest, windows-latest ?
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
+        include:
+          - {os: "macOS-12", python-version: "3.10"}
+          - {os: "ubuntu-22.04", python-version: "3.11"}
+          - {os: "ubuntu-22.04", python-version: "3.10"}
+          - {os: "ubuntu-22.04", python-version: "3.9"}
+          - {os: "ubuntu-20.04", python-version: "3.8"}
+          - {os: "ubuntu-20.04", python-version: "3.7"}
+        #os: [ubuntu-latest] # TODO: add macos-latest, windows-latest ?
+        #python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
 
     timeout-minutes: 30
 
     steps:
-    - uses: actions/checkout@master
-    - uses: actions/setup-python@master
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest] # TODO: add macos-latest, windows-latest ?
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
 
     timeout-minutes: 30
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest] # TODO: add macos-latest, windows-latest ?
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12]
 
     timeout-minutes: 30
 

--- a/dadapy/metric_comparisons.py
+++ b/dadapy/metric_comparisons.py
@@ -607,6 +607,8 @@ class MetricComparisons(Base):
         Returns:
             (float): the neighbour overlap of the points
         """
+        assert False, """This function is outdated and will be removed in a future version of the package. \
+        Use "compute_label_overlap" instead."""
         assert self.X is not None
 
         X_ = self.X[:, coords]
@@ -635,6 +637,10 @@ class MetricComparisons(Base):
         Returns:
             (float): the neighbour overlap of the two subspaces
         """
+        assert False, """This function is a wrong implementation of the overlap between two \
+            sets of coordinates and will be removed in a future version of the package. \
+            Use "compute_data_overlap" instead."""
+
         assert self.X is not None
 
         X1_ = self.X[:, coords1]
@@ -660,6 +666,9 @@ class MetricComparisons(Base):
         Returns:
             (list(float)): a list of neighbour overlaps of the points
         """
+        assert False, """This function is a wrong implementation of the overlap between two \
+            sets of coordinates and will be removed in a future version of the package. \
+            Use "compute_data_overlap" instead."""
         assert self.X is not None
 
         overlaps = []

--- a/dadapy/metric_comparisons.py
+++ b/dadapy/metric_comparisons.py
@@ -618,8 +618,11 @@ class MetricComparisons(Base):
         Returns:
             (float): the neighbour overlap of the points
         """
-        assert False, """This function is outdated and will be removed in a future version of the package. \
+        raise AssertionError(
+            """This function is outdated and will be removed in a future version of the package. \
         Use "compute_label_overlap" instead."""
+        )
+
         assert self.X is not None
 
         X_ = self.X[:, coords]
@@ -648,9 +651,11 @@ class MetricComparisons(Base):
         Returns:
             (float): the neighbour overlap of the two subspaces
         """
-        assert False, """This function is a wrong implementation of the overlap between two \
+        raise AssertionError(
+            """This function is a wrong implementation of the overlap between two \
             sets of coordinates and will be removed in a future version of the package. \
             Use "compute_data_overlap" instead."""
+        )
 
         assert self.X is not None
 
@@ -677,9 +682,11 @@ class MetricComparisons(Base):
         Returns:
             (list(float)): a list of neighbour overlaps of the points
         """
-        assert False, """This function is a wrong implementation of the overlap between two \
+        raise AssertionError(
+            """This function is a wrong implementation of the overlap between two \
             sets of coordinates and will be removed in a future version of the package. \
             Use "compute_data_overlap" instead."""
+        )
         assert self.X is not None
 
         overlaps = []

--- a/tests/test_metric_comparisons/test_neighbour_overlap.py
+++ b/tests/test_metric_comparisons/test_neighbour_overlap.py
@@ -25,18 +25,6 @@ from dadapy import MetricComparisons
 filename = os.path.join(os.path.split(__file__)[0], "../3d_gauss_small_z_var.npy")
 
 
-def test_return_overlap_coords():
-    """Test that the neighbourhood overlap works correctly."""
-    X = np.load(filename)
-
-    mc = MetricComparisons(coordinates=X)
-    mc.compute_distances()
-    # check equivalence of x-y subspace with the full x-y-z space on this dataset
-    overlap = mc.return_overlap_coords(coords1=[0, 1, 2], coords2=[0, 1])
-
-    assert overlap == pytest.approx(0.992, abs=0.0001)
-
-
 def test_return_label_overlap():
     """Test that the label overlap works correctly."""
     X1 = np.load(filename)
@@ -52,30 +40,7 @@ def test_return_label_overlap():
     mc.compute_distances()
     overlap = mc.return_label_overlap(labels=labels)
 
-    assert overlap == 0.8676666666666668
-
-
-def test_return_label_overlap_selected_coords():
-    """Test that the label overlap works correctly."""
-    X = np.load(filename)
-
-    # labels simply distinguish left from right
-    labels = np.ones(X.shape[0])
-    labels[np.where(X[:, 0] < 0)] = 0
-
-    coord_list = [[0, 1, 2], [0], [1], [2]]
-    # coordinate 0 is expected to better distinguish left and right
-    expected_overlaps = [0.7783333333333333, 0.927, 0.494, 0.48533333333333334]
-
-    mc = MetricComparisons(coordinates=X, maxk=X.shape[0] - 1)
-
-    mc.compute_distances()
-
-    overlaps = mc.return_label_overlap_selected_coords(
-        labels=labels, coord_list=coord_list
-    )
-
-    assert overlaps == pytest.approx(expected_overlaps)
+    assert overlap == pytest.approx(0.8676666666666668, 0.001)
 
 
 def test_return_data_overlap():

--- a/tox.ini
+++ b/tox.ini
@@ -96,3 +96,11 @@ deps =
     nbmake>=1.4,<1.5
 commands:
     pytest examples/notebook_on_intrinsicdim_densityest_clustering.ipynb examples/notebook_on_information_imbalance.ipynb --nbmake --nbmake-timeout=300
+
+[testenv:py3.12-nb]
+basepython = python3.12
+deps =
+    pytest>=7.4.0,<7.5.0
+    nbmake>=1.4,<1.5
+commands:
+    pytest examples/notebook_on_intrinsicdim_densityest_clustering.ipynb examples/notebook_on_information_imbalance.ipynb --nbmake --nbmake-timeout=300

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # isolated_build = True
-envlist = black-check, isort-check, py3.7, py3.8, py3.9, py3.10, py3.11, py3.12
+envlist = black-check, isort-check, py3.7, py3.8, py3.9, py3.10, py3.11
 # vulture, flake8, pylint,
 
 [tox:.package]
@@ -44,9 +44,6 @@ basepython = python3.10
 
 [testenv:py3.11]
 basepython = python3.11
-
-[testenv:py3.12]
-basepython = python3.12
 
 
 [testenv:black]
@@ -97,8 +94,8 @@ deps =
 commands:
     pytest examples/notebook_on_intrinsicdim_densityest_clustering.ipynb examples/notebook_on_information_imbalance.ipynb --nbmake --nbmake-timeout=300
 
-[testenv:py3.12-nb]
-basepython = python3.12
+[testenv:py3.11-nb]
+basepython = python3.11
 deps =
     pytest>=7.4.0,<7.5.0
     nbmake>=1.4,<1.5


### PR DESCRIPTION
1. I removed wrong and redundant return_overlap coord. Now compute_data_overlap must be used;
2. removed also the reduntant 'return_label_overlap_coords' 'return_label_overap_selected_coord'. Now return label overlap should be used.
3. added new test environments (python 10, 11, 12) in .yml files
