### PR TITLE
Fix DII unittests for newer Python versions

### DIFF
--- a/dadapy/feature_weighting.py
+++ b/dadapy/feature_weighting.py
@@ -697,7 +697,7 @@ class FeatureWeighting(Base):
             end = time.time()
             if self.verb:
                 print(
-                    f"optimization with l1-penalty {i+1} of strength "
+                    f"optimization with l1-penalty {i + 1} of strength "
                     + f"{l1_penalties[i]:.4g} took: {end - start:.2f} s.",
                 )
 

--- a/tests/test_feature_weighting/test_differentiable_imbalance.py
+++ b/tests/test_feature_weighting/test_differentiable_imbalance.py
@@ -28,7 +28,7 @@ rng = np.random.default_rng()
 def test_typing():
     """Test typing decorator function."""
     data = rng.random((10, 5))
-    for dtype in [np.float16, np.float32, np.double, np.float64, np.float128]:
+    for dtype in [np.float16, np.float32, np.double, np.float64]:
         # This should run with only floats as input arrays
         dist_mat = dii._return_full_dist_matrix(
             data.astype(dtype), period=np.zeros(5, dtype=dtype), n_jobs=1, cythond=True
@@ -45,7 +45,6 @@ def test_typing():
     assert cast_func(np.zeros(10, dtype=np.int64))[0][0].dtype == np.int64
 
     assert cast_func(np.zeros(10, dtype=np.float16))[0][0].dtype == dii.CYTHON_DTYPE
-    assert cast_func(np.zeros(10, dtype=np.float128))[0][0].dtype == dii.CYTHON_DTYPE
     assert cast_func(np.zeros(10, dtype=np.double))[0][0].dtype == dii.CYTHON_DTYPE
 
     assert cast_func(0, test=np.zeros(10, dtype=np.float16))[0][0] == 0

--- a/tests/test_feature_weighting/test_selection.py
+++ b/tests/test_feature_weighting/test_selection.py
@@ -71,7 +71,7 @@ def test_maxk_warning():
     data = rng.random((10, 5))
     feature_selection = FeatureWeighting(data, maxk=3)
 
-    with pytest.warns():
+    with pytest.warns(UserWarning):
         feature_selection.return_dii_gradient(Data(data), weights=np.zeros(5))
 
 


### PR DESCRIPTION
## Proposed changes

numpy and pytest deprecations have made some unittests crash in newer python versions.
Small changes in unittests to account for this

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
