### PR TITLE
codecov: update to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
       run: |
         tox -e py${{ matrix.python-version }}
     - name: "Upload coverage to Codecov"
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v4
       with:
         fail_ci_if_error: false
 #    - name: Upload coverage to Codecov


### PR DESCRIPTION
fixing the CIs on MacOS by updating codecov to v4