### PR TITLE
BID docs added

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ overlap_labels = data.return_label_overlap(labels)
   > Denti et al., *Scientific Reports* (2022)
 - I3D estimator (for both continuous and discrete spaces)
   > Macocco et al., *Physical Review Letters* (2023)
+- BID estimator
+  > Acevedo et al., *Nature Communications Physics* (2025)
+  
 - Density estimators
     - 
 - kNN estimator

--- a/docs/source/hamming.rst
+++ b/docs/source/hamming.rst
@@ -1,0 +1,5 @@
+The hamming module
+================================
+
+.. automodule:: hamming
+    :members:

--- a/docs/source/implemented_algorithms.rst
+++ b/docs/source/implemented_algorithms.rst
@@ -13,7 +13,7 @@ The algorithms currently implemented are:
 
 * Two NN ("Two nearest neighbour estimator")
 * Gride ("Generalized ratios id estimator")
-
+* BID ("Binary intrinsic dimension")
 
 Density estimation
 -----------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -26,6 +26,7 @@ The code can be found on GitHub at https://github.com/sissa-data-science/DADApy.
    jupyter_example_6
    jupyter_example_7
    jupyter_example_8
+   jupyter_example_9
    hands_on_tutorial_at_SISSA
    citing
    

--- a/docs/source/jupyter_example_9.nblink
+++ b/docs/source/jupyter_example_9.nblink
@@ -1,0 +1,4 @@
+{
+    "path": "../../examples/notebook_hamming.ipynb"
+
+}

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -18,5 +18,6 @@ The package contains the following modules:
    id_discrete
    metric_comparisons
    feature_weighting
+   hamming
    data
    utils


### PR DESCRIPTION
## Proposed changes

I simply added the BID estimator in the README and in the "readthedocs". I mimicked what I've seen in https://github.com/sissa-data-science/DADApy/tree/main/docs/source  , so please let me know if there is something wrong or missing. 