### PR TITLE
Linting & cleanup

### DIFF
--- a/dadapy/__init__.py
+++ b/dadapy/__init__.py
@@ -1,20 +1,22 @@
+"""DADApy: a Python package for Distance-based Analysis of DAta-manifolds."""
+
 import sys
 
-from ._utils.utils import *
-from .base import Base
-from .clustering import Clustering
-from .data import Data
-from .data_sets import DataSets
-from .density_advanced import DensityAdvanced
-from .density_estimation import DensityEstimation
-from .feature_weighting import FeatureWeighting
-from .id_discrete import IdDiscrete
-from .id_estimation import IdEstimation
-from .kstar import KStar
-from .metric_comparisons import MetricComparisons
-from .neigh_graph import NeighGraph
+from ._utils.utils import *  # noqa: F401,F403
+from .base import Base  # noqa: F401
+from .clustering import Clustering  # noqa: F401
+from .data import Data  # noqa: F401
+from .data_sets import DataSets  # noqa: F401
+from .density_advanced import DensityAdvanced  # noqa: F401
+from .density_estimation import DensityEstimation  # noqa: F401
+from .feature_weighting import FeatureWeighting  # noqa: F401
+from .id_discrete import IdDiscrete  # noqa: F401
+from .id_estimation import IdEstimation  # noqa: F401
+from .kstar import KStar  # noqa: F401
+from .metric_comparisons import MetricComparisons  # noqa: F401
+from .neigh_graph import NeighGraph  # noqa: F401
 
 if sys.version_info >= (3, 9):
-    from .causal_graph import CausalGraph
-    from .diff_imbalance import DiffImbalance
-    from .hamming import BID, Hamming
+    from .causal_graph import CausalGraph  # noqa: F401
+    from .diff_imbalance import DiffImbalance  # noqa: F401
+    from .hamming import BID, Hamming  # noqa: F401

--- a/dadapy/__init__.py
+++ b/dadapy/__init__.py
@@ -3,20 +3,37 @@
 import sys
 
 from ._utils.utils import *  # noqa: F401,F403
-from .base import Base  # noqa: F401
-from .clustering import Clustering  # noqa: F401
-from .data import Data  # noqa: F401
-from .data_sets import DataSets  # noqa: F401
-from .density_advanced import DensityAdvanced  # noqa: F401
-from .density_estimation import DensityEstimation  # noqa: F401
-from .feature_weighting import FeatureWeighting  # noqa: F401
-from .id_discrete import IdDiscrete  # noqa: F401
-from .id_estimation import IdEstimation  # noqa: F401
-from .kstar import KStar  # noqa: F401
-from .metric_comparisons import MetricComparisons  # noqa: F401
-from .neigh_graph import NeighGraph  # noqa: F401
+from .base import Base
+from .clustering import Clustering
+from .data import Data
+from .data_sets import DataSets
+from .density_advanced import DensityAdvanced
+from .density_estimation import DensityEstimation
+from .feature_weighting import FeatureWeighting
+from .id_discrete import IdDiscrete
+from .id_estimation import IdEstimation
+from .kstar import KStar
+from .metric_comparisons import MetricComparisons
+from .neigh_graph import NeighGraph
+
+__all__ = [
+    "Base",
+    "Clustering",
+    "Data",
+    "DataSets",
+    "DensityAdvanced",
+    "DensityEstimation",
+    "FeatureWeighting",
+    "IdDiscrete",
+    "IdEstimation",
+    "KStar",
+    "MetricComparisons",
+    "NeighGraph",
+]
 
 if sys.version_info >= (3, 9):
-    from .causal_graph import CausalGraph  # noqa: F401
-    from .diff_imbalance import DiffImbalance  # noqa: F401
-    from .hamming import BID, Hamming  # noqa: F401
+    from .causal_graph import CausalGraph
+    from .diff_imbalance import DiffImbalance
+    from .hamming import BID, Hamming
+
+    __all__ += ["CausalGraph", "DiffImbalance", "BID", "Hamming"]

--- a/dadapy/causal_graph.py
+++ b/dadapy/causal_graph.py
@@ -27,13 +27,12 @@ import warnings
 import matplotlib.pyplot as plt
 import networkx as nx
 import numpy as np
-from tqdm.auto import tqdm
 
 from dadapy.diff_imbalance import DiffImbalance
 
 
 def symbol_generator():
-    """Generates the alphanumeric strings used to label the dynamical communities."""
+    """Generate the alphanumeric strings used to label the dynamical communities."""
     yield from string.ascii_uppercase
     for i in itertools.count(1):
         for c in string.ascii_uppercase:
@@ -69,6 +68,7 @@ class CausalGraph(DiffImbalance):
         standardize=True,
         seed=0,
     ):
+        """Initialise the CausalGraph object."""
         self.time_series = time_series
         self.coords_present = coords_present
         self.coords_future = coords_future
@@ -93,7 +93,7 @@ class CausalGraph(DiffImbalance):
         self.errors_final_refine = None
 
     def _check_and_initialize_args(self, periods):
-        """Checks input arguments to constructor of CausalGraph object."""
+        """Check input arguments to constructor of CausalGraph object."""
         num_variables = None
         periods = periods
         if (
@@ -103,14 +103,13 @@ class CausalGraph(DiffImbalance):
         ):
             assert len(self.coords_future.shape) == 3, (
                 f"Coords_future has shape {self.coords_future.shape}, while the expected shape "
-                + f"is (N_samples, D_features, n_lags).\nIf you want to test a single time lag, "
-                + f"provide as input coords_future[:,:,np.newaxis]."
+                + "is (N_samples, D_features, n_lags).\nIf you want to test a single time lag, "
+                + "provide as input coords_future[:,:,np.newaxis]."
             )
-            n_lags = self.coords_future.shape[2]
             assert self.coords_present.shape == self.coords_future.shape[:2], (
                 "Arguments coords_present and coords_future should have shapes (N_samples, D_features) "
-                + f"and (N_samples, D_features, n_lags),\n but the number of samples and/or the "
-                + f"number of features do not match."
+                + "and (N_samples, D_features, n_lags),\n but the number of samples and/or the "
+                + "number of features do not match."
             )
             num_variables = self.coords_present.shape[1]
             if periods is not None:
@@ -123,7 +122,8 @@ class CausalGraph(DiffImbalance):
                 ).any()
             ):
                 warnings.warn(
-                    f"The {num_variables} variables in 'coords_present' are not standardized."
+                    f"The {num_variables} variables in 'coords_present' are not standardized.",
+                    stacklevel=2,
                 )
             if self.standardize is True:
                 self.coords_present /= np.std(
@@ -132,12 +132,13 @@ class CausalGraph(DiffImbalance):
         elif self.time_series is not None:
             if self.coords_present is not None or self.coords_future is not None:
                 warnings.warn(
-                    f"You passed the whole time series as input; the arguments coords_present and "
-                    + f"coords_future will be ignored"
+                    "You passed the whole time series as input; the arguments coords_present and "
+                    + "coords_future will be ignored",
+                    stacklevel=2,
                 )
             num_variables = self.time_series.shape[1]
             if periods is not None:
-                periods = np.ones(time_series.shape[1]) * np.array(periods)
+                periods = np.ones(self.time_series.shape[1]) * np.array(periods)
             if (
                 self.standardize is False
                 and (
@@ -145,7 +146,8 @@ class CausalGraph(DiffImbalance):
                 ).any()
             ):
                 warnings.warn(
-                    f"Warning: the {num_variables} variables of the input time series are not standardized."
+                    f"Warning: the {num_variables} variables of the input time series are not standardized.",
+                    stacklevel=2,
                 )
             if self.standardize is True:
                 self.time_series /= np.std(
@@ -162,10 +164,11 @@ class CausalGraph(DiffImbalance):
         embedding_time=1,
         discard_close_ind=None,
     ):
-        """Returns the indices of the nearest neighbor of each point.
+        """Return the indices of the nearest neighbor of each point.
 
         Args:
-            variables (list, jnp.array(int)): array of the coordinates used to build the distance space (with weights 1).
+            variables (list, jnp.array(int)): array of the coordinates used to build the distance space
+                (with weights 1).
             num_samples (int): number of samples harvested from the full time series.
             time_lags (list(int), np.array(int)): tested time lags between 'present' and 'future'.
             embedding_dim (int): dimension of the time-delay embedding vector built on each variable. Default is 1,
@@ -176,8 +179,8 @@ class CausalGraph(DiffImbalance):
                 point i, distances between i and points within [i-discard_close_ind, i+discard_close_ind] are discarded.
 
         Returns:
-            nn_indices (np.array(float)): array of the nearest neighbors indices: nn_indices[i] is the index of the column
-                with value 1 in the rank matrix.
+            nn_indices (np.array(float)): array of the nearest neighbors indices: nn_indices[i] is the
+                index of the column with value 1 in the rank matrix.
         """
         assert (
             self.time_series is not None
@@ -215,7 +218,7 @@ class CausalGraph(DiffImbalance):
         nn_indices = dii._return_nn_indices(discard_close_ind=discard_close_ind)
         return np.array(nn_indices)
 
-    def optimize_present_to_future(
+    def optimize_present_to_future(  # noqa: C901
         self,
         num_samples,
         time_lags,
@@ -241,7 +244,7 @@ class CausalGraph(DiffImbalance):
         ratio_rows_columns=1,
         discard_close_ind=None,
     ):
-        """Iteratively optimizes the DII from the full space in the present to a target space in the future.
+        """Optimize the DII iteratively from the full space in the present to a target space in the future.
 
         Arguments 'num_samples', 'time_lags', 'embedding_dim_present', 'embedding_dim_future' and 'embedding_time'
         are read only when data are provided to the CausalGraph object through the argument 'time_series'.
@@ -289,9 +292,9 @@ class CausalGraph(DiffImbalance):
                 with the attribute learning_rate. The available schedules are: cosine decay ("cos"), exponential
                 decay ("exp"; the initial learning rate is halved every 10 steps), or constant learning rate (None).
                 Default is None (constant learning rate).
-            num_points_rows (int): number of points sampled from the rows of rank and distance matrices. In case of large
-                datasets, choosing num_points_rows < n_points can significantly speed up the training. The default is
-                None, for which num_points_rows == n_points.
+            num_points_rows (int): number of points sampled from the rows of rank and distance matrices.
+                In case of large datasets, choosing num_points_rows < n_points can significantly speed
+                up the training. The default is None, for which num_points_rows == n_points.
             compute_imb_final (bool): whether to compute the final DII over the full data set, using the options
                 specified by 'compute_error', 'ratio_rows_columns' and 'discard_close_ind'. Default is False, for
                 which those arguments are ignored.
@@ -321,17 +324,18 @@ class CausalGraph(DiffImbalance):
             imbs_final (np.array(float)): array of shape (n_target_variables, n_time_lags) containing the DII at
                 the end of each training computed over the full data set. If 'compute_imb_final' is False, imbs_final
                 is set to None. Also accessible as attribute of the CausalGraph object.
-            errors_final (np.array(float)): array of shape (n_target_variables, n_time_lags) containing the errors
-                of the DII at the end of each training, computed over the full data set. If 'compute_imb_final' is False,
-                or if 'compute_imb_final' is True and 'compute_error' is False, errors_final is set to None. Also
-                accessible as attribute of the CausalGraph object.
+            errors_final (np.array(float)): array of shape (n_target_variables, n_time_lags) containing
+                the errors of the DII at the end of each training, computed over the full data set.
+                If 'compute_imb_final' is False, or if 'compute_imb_final' is True and 'compute_error'
+                is False, errors_final is set to None. Also accessible as attribute of the
+                CausalGraph object.
         """
         coords_present = None
         if self.time_series is not None:
             assert num_samples <= self.time_series.shape[0] - max(time_lags), (
                 f"Error: cannot extract {num_samples} samples from {self.time_series.shape[0]} initial "
                 + f"samples, if the maximum time lag is {np.max(time_lags)}.\nChoose a smaller value of "
-                + f"num_samples."
+                + "num_samples."
             )
 
             t0s = np.linspace(
@@ -355,16 +359,18 @@ class CausalGraph(DiffImbalance):
             )
         elif self.coords_present is not None:
             if num_samples is not None:
-                warninings.warn(
-                    f"Argument 'num_samples' will be ignored, as you already provided the independent "
-                    + f"initial conditions through arguments 'coords_present' and 'coords_future'.\n "
-                    + f"To suppress this warning, set 'num_samples' to None."
+                warnings.warn(
+                    "Argument 'num_samples' will be ignored, as you already provided the independent "
+                    + "initial conditions through arguments 'coords_present' and 'coords_future'.\n "
+                    + "To suppress this warning, set 'num_samples' to None.",
+                    stacklevel=2,
                 )
             if time_lags is not None:
-                warninings.warn(
-                    f"Argument 'time_lags' will be ignored, as the samples at different time lags t=tau "
-                    + f"are already read from the last dimension of 'coords_future'.\n "
-                    + f"To suppress this warning, set 'time_lags' to None."
+                warnings.warn(
+                    "Argument 'time_lags' will be ignored, as the samples at different time lags t=tau "
+                    + "are already read from the last dimension of 'coords_future'.\n "
+                    + "To suppress this warning, set 'time_lags' to None.",
+                    stacklevel=2,
                 )
             num_samples = self.coords_present.shape[0]
             time_lags = np.arange(1, self.coords_future.shape[2] + 1)
@@ -372,7 +378,7 @@ class CausalGraph(DiffImbalance):
         else:
             print(
                 "To call this method, provide either a time series or directly the present and future samples "
-                + f"while initializing the CausalGraph class."
+                + "while initializing the CausalGraph class."
             )
 
         if target_variables == "all":
@@ -503,7 +509,7 @@ class CausalGraph(DiffImbalance):
         return weights_final, imbs_training, imbs_final, errors_final
 
     def compute_adj_matrix(self, weights, threshold=1e-1):
-        """Computes the adjacency matrix from the optimal weights returned by optimize_present_to_future.
+        """Compute the adjacency matrix from the optimal weights returned by optimize_present_to_future.
 
         As a preliminary step before applying the threshold, the maximum weight over the tested time lags is
         taken for each pair X_i(0) -> X_j(tau) (i,j=1,...,D). If the weights are referred to time-delay
@@ -524,16 +530,16 @@ class CausalGraph(DiffImbalance):
                 CausalGraph object.
         """
         assert weights is not None, (
-            f"To call this method, provide the weights obtained with the method optimize_present_to_future, "
-            + f"with the option target_variables='all'"
+            "To call this method, provide the weights obtained with the method optimize_present_to_future, "
+            + "with the option target_variables='all'"
         )
         assert len(weights.shape) == 3 or len(weights.shape) == 4, (
             "The array of weight must have shape (D,n_time_lags,D), or (D,n_time_lags,D,embedding_dim_present). "
-            + f"If you are testing a single time lag, reshape this input as weights[:,np.newaxis,:]."
+            + "If you are testing a single time lag, reshape this input as weights[:,np.newaxis,:]."
         )
         assert weights.shape[0] == weights.shape[2], (
             "The array of weight must have shape (D,n_time_lags,D), or (D,n_time_lags,D,embedding_dim_present), "
-            + f"where D is the number of variables."
+            + "where D is the number of variables."
         )
         if len(weights.shape) == 3:
             weights_max = np.max(weights, axis=1)  # maximum over all tested time lags
@@ -549,7 +555,7 @@ class CausalGraph(DiffImbalance):
         return adj_matrix
 
     def _ancestors(self, adj_matrix):
-        """Finds ancestors of each node in the directed graph described by the input adjacency matrix.
+        """Find ancestors of each node in the directed graph described by the input adjacency matrix.
 
         Args:
             adj_matrix (np.ndarray(float)): binary matrix of shape (D,D) defining the links of a directed
@@ -566,7 +572,7 @@ class CausalGraph(DiffImbalance):
         return auto_sets
 
     def find_communities(self, adj_matrix):
-        """Finds dynamical communities, i.e. groups of variables defining single nodes in the community causal graph.
+        """Find dynamical communities, i.e. groups of variables defining single nodes in the community causal graph.
 
         Args:
             adj_matrix (np.ndarray(float)): binary matrix of shape (D,D) defining the links of a directed
@@ -636,7 +642,7 @@ class CausalGraph(DiffImbalance):
         self.community_dictionary = community_dictionary
         return community_dictionary
 
-    def community_graph_visualization(
+    def community_graph_visualization(  # noqa: C901
         self,
         community_dictionary,
         adj_matrix,
@@ -645,7 +651,7 @@ class CausalGraph(DiffImbalance):
         variable_names=None,
         **kwargs,
     ):
-        """Shows a visual representation of the dynamical communities on a graph.
+        """Show a visual representation of the dynamical communities on a graph.
 
         This function makes use of the library networkx (https://networkx.org/documentation/stable/index.html)
 
@@ -698,7 +704,7 @@ class CausalGraph(DiffImbalance):
 
             assert (
                 len(communities) != 1
-            ), f"Only one community is present. Try plotting with a standard function of networkx."
+            ), "Only one community is present. Try plotting with a standard function of networkx."
 
             G = nx.DiGraph()
             for comm in communities:
@@ -791,9 +797,6 @@ class CausalGraph(DiffImbalance):
                 tuple(community): alphabet_string[i]
                 for i, community in enumerate(values)
             }
-            from_names_to_communities = {
-                community_names[key]: key for key in community_names.keys()
-            }
 
             # convert communities into names and add them to graph as nodes
             for community, key in zip(community_names, keys):
@@ -806,7 +809,8 @@ class CausalGraph(DiffImbalance):
                     )
                 else:
                     print(
-                        f"Community {community_name} ({len(community)} variables, level {key[1]}): {variable_names[list(community)]}"
+                        f"Community {community_name} ({len(community)} variables, "
+                        f"level {key[1]}): {variable_names[list(community)]}"
                     )
 
             # dictionary with keys: (order_idx) and values: list of communities at that order (list of list)
@@ -817,7 +821,7 @@ class CausalGraph(DiffImbalance):
                 )
 
             # draw edges
-            for community_effect_idx, order_idx in keys:
+            for _community_effect_idx, order_idx in keys:
                 if order_idx == 0:
                     continue
                 # for each putative effect community at order >=1...
@@ -862,7 +866,7 @@ class CausalGraph(DiffImbalance):
             # return networkx object
             return G
 
-    def find_direct_links_communities(
+    def find_direct_links_communities(  # noqa: C901
         self,
         adj_matrix,
         community_graph,
@@ -888,12 +892,13 @@ class CausalGraph(DiffImbalance):
         ratio_rows_columns=1,
         discard_close_ind=None,
     ):
-        """Implements the refinement step to distinguish direct and indirect links between nonconsecutive communities.
+        """Implement the refinement step to distinguish direct and indirect links between nonconsecutive communities.
 
         Whenever a pattern A->C->B is found in the community causal graph, the loss
             DII(w * [A(0), B(tau-1), C(tau-1),..., B(tau-E), C(tau-E)] -> B(tau))
-        is optimized for all input time lags 'tau'. All variables within the same community are scaled by the same weight.
-        The number of previous time steps E included in the optimization is given by the argument 'embedding_dim_present'.
+        is optimized for all input time lags 'tau'. All variables within the same community are scaled
+        by the same weight. The number of previous time steps E included in the optimization is given
+        by the argument 'embedding_dim_present'.
 
         Arguments 'num_samples', 'time_lags', 'embedding_dim_present', 'embedding_dim_future' and 'embedding_time'
         are read only when data are provided to the CausalGraph object through the argument 'time_series'.
@@ -947,9 +952,9 @@ class CausalGraph(DiffImbalance):
                 with the attribute learning_rate. The available schedules are: cosine decay ("cos"), exponential
                 decay ("exp"; the initial learning rate is halved every 10 steps), or constant learning rate (None).
                 Default is None (constant learning rate).
-            num_points_rows (int): number of points sampled from the rows of rank and distance matrices. In case of large
-                datasets, choosing num_points_rows < n_points can significantly speed up the training. The default is
-                None, for which num_points_rows == n_points.
+            num_points_rows (int): number of points sampled from the rows of rank and distance matrices.
+                In case of large datasets, choosing num_points_rows < n_points can significantly speed
+                up the training. The default is None, for which num_points_rows == n_points.
             compute_imb_final (bool): whether to compute the final DII over the full data set, using the options
                 specified by 'compute_error', 'ratio_rows_columns' and 'discard_close_ind'. Default is False, for
                 which those arguments are ignored.
@@ -970,19 +975,23 @@ class CausalGraph(DiffImbalance):
                 no distances between points close in the time are discarded.
 
         Returns:
-            weights_final (dict): dictionary containing the final optimization weights for each pair of communities
-                linked through indirect paths in the community causal graph. The keys are tuples (community_name_cause,
-                community_name_effect), while the values are np.arrays of shape (n_time_lags, n_weights), where n_weights
-                is equal to 1 + E + E (1 weight for the cause community, E weights for the effect community, and E weights
+            weights_final (dict): dictionary containing the final optimization weights for each pair
+                of communities linked through indirect paths in the community causal graph. The keys
+                are tuples (community_name_cause, community_name_effect), while the values are
+                np.arrays of shape (n_time_lags, n_weights), where n_weights is equal to 1 + E + E
+                (1 weight for the cause community, E weights for the effect community, and E weights
                 for the mediator communities), and E=embedding_dim_present.
-            communities_and_lags (dict): dictionary containing as keys the tuples (community_name_cause, community_name_effect),
-                and as values the a list of communities and corresponding lags
-            imbs_training (dict): dictionary containing as keys the tuples (community_name_cause, community_name_effect), and
-                as values the DIIs during the trainings.
-            imbs_final (dict): dictionary containing as keys the tuples (community_name_cause, community_name_effect), and as
-                values the final DIIs.
-            errors_final (dict): dictionary containing as keys the tuples (community_name_cause, community_name_effect), and as
-                values the errors of the final DIIs.
+            communities_and_lags (dict): dictionary containing as keys the tuples
+                (community_name_cause, community_name_effect), and as values a list of communities
+                and corresponding lags.
+            imbs_training (dict): dictionary containing as keys the tuples
+                (community_name_cause, community_name_effect), and as values the DIIs during the
+                trainings.
+            imbs_final (dict): dictionary containing as keys the tuples
+                (community_name_cause, community_name_effect), and as values the final DIIs.
+            errors_final (dict): dictionary containing as keys the tuples
+                (community_name_cause, community_name_effect), and as values the errors of the
+                final DIIs.
         """
 
         def find_mediators(graph, node_start, node_end):
@@ -1033,8 +1042,8 @@ class CausalGraph(DiffImbalance):
         errors_final = {}
         communities_and_lags = {}
 
-        ############# identify all pairs of indirectly linked communities, and mediator communities #############
-        for community_effect_idx, order_idx in keys:
+        # identify all pairs of indirectly linked communities, and mediator communities #############
+        for _community_effect_idx, order_idx in keys:
             if order_idx < 2:
                 continue
             # for each putative effect community at order >=2...
@@ -1045,10 +1054,6 @@ class CausalGraph(DiffImbalance):
                 effect_ancestors_names = set(
                     nx.ancestors(community_graph, community_name_effect)
                 )
-                effect_ancestors_sets = [
-                    from_names_to_communities[effect_ancestor_name]
-                    for effect_ancestor_name in effect_ancestors_names
-                ]
 
                 # ...and take each ancestor (not a parent!) community as putative cause...
                 for community_name_cause in list(
@@ -1068,7 +1073,8 @@ class CausalGraph(DiffImbalance):
                         ).all()
                     ):
                         print(
-                            f"Communities {community_name_cause}->{community_name_effect}: not linked according to adjacency matrix, test skipped."
+                            f"Communities {community_name_cause}->{community_name_effect}: "
+                            "not linked according to adjacency matrix, test skipped."
                         )
                         continue
 
@@ -1126,7 +1132,7 @@ class CausalGraph(DiffImbalance):
                                 community_name_cause, community_name_effect
                             ] = np.zeros(len(time_lags))
 
-                    ########### compute DII((cause(t=0), effect(t=tau-1), ... , mediator(t=tau-1), ...) -> effect(t=tau))
+                    # compute DII((cause(t=0), effect(t=tau-1), ... , mediator(t=tau-1), ...) -> effect(t=tau))
                     coords_present = None
                     variables_t0 = community_cause
                     if self.time_series is not None:
@@ -1135,7 +1141,7 @@ class CausalGraph(DiffImbalance):
                         ), (
                             f"Error: cannot extract {num_samples} samples from {self.time_series.shape[0]} initial "
                             + f"samples, if the maximum time lag is {np.max(time_lags)}.\nChoose a smaller value of "
-                            + f"num_samples."
+                            + "num_samples."
                         )
 
                         t0s = np.linspace(
@@ -1151,27 +1157,29 @@ class CausalGraph(DiffImbalance):
                         ]  # has shape (num_samples, n_variables_t0)
                     elif self.coords_present is not None:
                         if num_samples is not None:
-                            warninings.warn(
-                                f"Argument 'num_samples' will be ignored, as you already provided the independent "
-                                + f"initial conditions through arguments 'coords_present' and 'coords_future'.\n "
-                                + f"To suppress this warning, set 'num_samples' to None."
+                            warnings.warn(
+                                "Argument 'num_samples' will be ignored, as you already provided the independent "
+                                + "initial conditions through arguments 'coords_present' and 'coords_future'.\n "
+                                + "To suppress this warning, set 'num_samples' to None.",
+                                stacklevel=2,
                             )
                         if time_lags is not None:
-                            warninings.warn(
-                                f"Argument 'time_lags' will be ignored, as the samples at different time lags t=tau "
-                                + f"are already read from the last dimension of 'coords_future'.\n "
-                                + f"To suppress this warning, set 'time_lags' to None."
+                            warnings.warn(
+                                "Argument 'time_lags' will be ignored, as the samples at different time lags t=tau "
+                                + "are already read from the last dimension of 'coords_future'.\n "
+                                + "To suppress this warning, set 'time_lags' to None.",
+                                stacklevel=2,
                             )
                         num_samples = self.coords_present.shape[0]
                         time_lags = np.arange(1, self.coords_future.shape[2] + 1)
                         coords_present = self.coords_present[:, variables_t0]
                     else:
                         print(
-                            "To call this method, provide either a time series or directly the present and future samples "
-                            + f"while initializing the CausalGraph class."
+                            "To call this method, provide either a time series or directly the "
+                            "present and future samples while initializing the CausalGraph class."
                         )
 
-                    ############# LOOP OVER TAU #############
+                    # LOOP OVER TAU #############
                     for j_tau, tau in enumerate(time_lags):
                         indices_future = (  # for space B: effect(t=tau)
                             np.array(
@@ -1246,8 +1254,11 @@ class CausalGraph(DiffImbalance):
                             coords_future = self.coords_future[
                                 :, community_effect, j_tau
                             ]
-                            coords_cond = self.coords_future[
-                                :, mediator_vars, j_tau - 1 : jtau + 1
+                            # TODO: this branch was unreachable due to a typo (jtau) and the
+                            # resulting array is currently unused downstream; revisit when the
+                            # else-branch path is exercised.
+                            coords_cond = self.coords_future[  # noqa: F841
+                                :, mediator_vars, j_tau - 1 : j_tau + 1
                             ]
 
                         coords_A = np.concatenate(
@@ -1361,7 +1372,7 @@ class CausalGraph(DiffImbalance):
         savefig_name=None,
         **kwargs,
     ):
-        """Shows a visual representation of the dynamical communities on a graph, after the refinement step.
+        """Show a visual representation of the dynamical communities on a graph, after the refinement step.
 
         This function makes use of the library networkx (https://networkx.org/documentation/stable/index.html)
 
@@ -1397,9 +1408,6 @@ class CausalGraph(DiffImbalance):
         community_names = {
             tuple(community): alphabet_string[i] for i, community in enumerate(values)
         }
-        from_names_to_communities = {
-            community_names[key]: key for key in community_names.keys()
-        }
 
         # print conversion labels - communities
         print("Conversion labels - communities:")
@@ -1411,7 +1419,8 @@ class CausalGraph(DiffImbalance):
                 )
             else:
                 print(
-                    f"Community {community_name} ({len(community)} variables, level {key[1]}): {variable_names[list(community)]}"
+                    f"Community {community_name} ({len(community)} variables, "
+                    f"level {key[1]}): {variable_names[list(community)]}"
                 )
 
         # extract pairs of communities tested for direct vs indirect links

--- a/dadapy/data_sets.py
+++ b/dadapy/data_sets.py
@@ -58,7 +58,8 @@ class DataSets:
         Args:
             d1 (Data): The first dataset
             d2 (Data): The second dataset
-            file_name (str, optional): The file where the imbalances are saved. Defaults to "jackknife.txt". Set to "None" to avoid saving.
+            file_name (str, optional): The file where the imbalances are saved. Defaults to
+                "jackknife.txt". Set to "None" to avoid saving.
             n (_type_, optional): Number of Jackknife repetitions. Defaults to the number of dataset points.
             k (int, optional): The number of neighbours for the imbalance computations. Defaults to 1.
 
@@ -66,12 +67,11 @@ class DataSets:
             mean and standard deviation of the imbalance estimates from d1 to d2.
         """
         assert len(d1.X) == len(d2.X)
-        if n == None:
+        if n is None:
             n = len(d1.X)
 
         if file_name is not None:
             print("Saving imbalances in " + file_name)
-            file_object = open(file_name, "a")
         else:
             print("Not saving imbalances")
 

--- a/dadapy/density_advanced.py
+++ b/dadapy/density_advanced.py
@@ -118,7 +118,7 @@ class DensityAdvanced(DensityEstimation, NeighGraph):
     # ----------------------------------------------------------------------------------------------
 
     def compute_grads(self, comp_covmat=False):
-        """Compute the gradient of the log density each point using kstar nearest neighbors and store
+        """Compute the gradient of the log density each point using kstar nearest neighbors and store it.
 
         Estimate the gradient using an improved version of the mean-shift gradient algorithm [Fukunaga1975] as
         presented in [Carli2024].
@@ -185,8 +185,9 @@ class DensityAdvanced(DensityEstimation, NeighGraph):
     # ----------------------------------------------------------------------------------------------
 
     def compute_pearson(self, similarity_method="jaccard"):
-        """
-        Compute, for any couple (i,j) of points connected on the directed neighbourhood graph, an estimate of the
+        """Compute Pearson correlation coefficient for the directed deltaFij of neighbour pairs.
+
+        For any couple (i,j) of points connected on the directed neighbourhood graph, estimate the
         Pearson correlation coefficient between the directed deltaFij computed with the gradients in i and in j, namely
         between dot(g_i,(x_j-x_i)) and dot(g_j,(x_j-x_i)). These are needed in order to compute the errors on the
         deltaFs. They are estimated as the neighbourhood similarity index (see documentation for
@@ -197,7 +198,6 @@ class DensityAdvanced(DensityEstimation, NeighGraph):
             similarity_method (str): similarity_method to compute the neighbourhood similarity index (see documentation
                 for compute_neigh_similarity_index).
         """
-
         # check or compute neigh_similarity_index
         if self.neigh_similarity_index is None:
             self.compute_neigh_similarity_index(method=similarity_method)
@@ -224,22 +224,22 @@ class DensityAdvanced(DensityEstimation, NeighGraph):
             )
 
     def compute_deltaFs(self, similarity_method="jaccard", comp_p_mat=False):
-        """Compute deviations deltaFij to standard kNN log-densities at point j as seen from point i using
-            a linear expansion with as slope the semisum of the average gradient of the log-density over
-            the neighbourhood of points i and j.
+        """Compute deviations deltaFij to standard kNN log-densities at neighbour pairs.
 
-            If not defined, compute the Pearson coefficients p (see docs for pearson_array) by running
-            compute_pearson.
-            Then use these p in the estimate of the variances on the deltaFij as 1/4*(E_i^2+E_j^2+2*E_i*E_j*chi), where
-            E_i is the error on the estimate of grad_i*DeltaX_ij (see [Carli2024]).
-            The log-density differences are stored Fij_array, their variances in Fij_array_var.
+        At point j as seen from point i, use a linear expansion with as slope the semisum of the
+        average gradient of the log-density over the neighbourhood of points i and j.
+
+        If not defined, compute the Pearson coefficients p (see docs for pearson_array) by running
+        compute_pearson.
+        Then use these p in the estimate of the variances on the deltaFij as 1/4*(E_i^2+E_j^2+2*E_i*E_j*chi), where
+        E_i is the error on the estimate of grad_i*DeltaX_ij (see [Carli2024]).
+        The log-density differences are stored Fij_array, their variances in Fij_array_var.
 
         Args:
             similarity_method: see docs for neigh_graph.compute_neigh_similarity_index function
             comp_p_mat: see docs for compute_pearson function
 
         """
-
         if self.grads_covmat is None:
             self.compute_grads(comp_covmat=True)
 
@@ -288,13 +288,13 @@ class DensityAdvanced(DensityEstimation, NeighGraph):
     def compute_diag_inv_deltaFs_cross_covariance_LSDI(
         self, similarity_method="jaccard"
     ):
-        """Compute the diagonal of the appoximate inverse of the deltaFs cross-covariance cov[deltaFij,deltaFlm] using
-        the LSDI approximation (see compute_density_BMTI docs)
+        """Compute the diagonal of the appoximate inverse of the deltaFs cross-covariance.
+
+        Targets cov[deltaFij,deltaFlm] using the LSDI approximation (see compute_density_BMTI docs).
 
         Args:
             similarity_method: see docs for neigh_graph.compute_neigh_similarity_index function
         """
-
         # check for deltaFs
         if self.neigh_similarity_index_mat is None:
             self.compute_neigh_similarity_index_mat(method=similarity_method)
@@ -417,7 +417,6 @@ class DensityAdvanced(DensityEstimation, NeighGraph):
             log_den_err (np.ndarray(float)): size N. The array of the log-density errors of the regulariser.
 
         """
-
         # compute changes in free energy
         if self.Fij_array is None:
             self.compute_deltaFs()
@@ -444,7 +443,8 @@ class DensityAdvanced(DensityEstimation, NeighGraph):
         if self.N > 10000 and solver == "dense":
             warnings.warn(
                 "The number of points is large and you are not using a memory efficient option. \
-                If you run into memory issues, consider using other options."
+                If you run into memory issues, consider using other options.",
+                stacklevel=2,
             )
 
         if self.verb:
@@ -497,7 +497,6 @@ class DensityAdvanced(DensityEstimation, NeighGraph):
                 np.ones(self.nspar, dtype=np.float64) / self.Fij_var_array / redundancy
             )
         elif delta_F_inv_cov == "LSDI":
-            # self.compute_deltaFs_inv_cross_covariance()
             self.compute_diag_inv_deltaFs_cross_covariance_LSDI()
             tmpvec = self.inv_deltaFs_cov
 
@@ -595,7 +594,8 @@ class DensityAdvanced(DensityEstimation, NeighGraph):
             # default solver: sp_direct
             if solver != "sp_direct":
                 warnings.warn(
-                    f"The solver '{solver}' selected is not among the options. Using 'sp_direct' instead."
+                    f"The solver '{solver}' selected is not among the options. Using 'sp_direct' instead.",
+                    stacklevel=2,
                 )
             if self.verb:
                 print(

--- a/dadapy/diff_imbalance.py
+++ b/dadapy/diff_imbalance.py
@@ -627,6 +627,7 @@ class DiffImbalance:
                 state_new (flax.training.train_state.TrainState object): new training state after optimizer step
                 imb (flat): new value of the DII after optimizer step.
             """
+
             def loss_fn(params):
                 return _compute_training_diff_imbalance(
                     params=params,

--- a/dadapy/diff_imbalance.py
+++ b/dadapy/diff_imbalance.py
@@ -42,7 +42,7 @@ from tqdm.auto import tqdm
 def _compute_dist2_matrix_scaling(
     params, batch_rows, batch_columns, periods=None, params_groups=None
 ):
-    """Computes the (squared) Euclidean distance matrix between points in 'batch_rows' and points in 'batch_columns'.
+    """Compute the (squared) Euclidean distance matrix between points in 'batch_rows' and points in 'batch_columns'.
 
     The features of the points are scaled by the weights in 'params', such that the distance between
     point i in batch_rows and point j in batch_columns is computed as
@@ -159,7 +159,7 @@ class DiffImbalance:
             None, for which num_points_rows == n_points.
     """
 
-    def __init__(
+    def __init__(  # noqa: C901
         self,
         data_A,
         data_B,
@@ -192,15 +192,16 @@ class DiffImbalance:
         else:  # space B provided as distances
             if data_B is not None:
                 warnings.warn(
-                    f"Argument distances_B is not None; data_B will be ignored."
+                    "Argument distances_B is not None; data_B will be ignored.",
+                    stacklevel=2,
                 )
-            # self.distances_B = jnp.array(distances_B)
+            # self.distances_B = jnp.array(distances_B)  # noqa: E800
             assert (
                 distances_B.shape[0] == distances_B.shape[1]
             ), f"Argument distances_B should be a square matrix, while it has shape {distances_B.shape}"
             assert data_A.shape[0] == distances_B.shape[0], (
                 f"Number of points in data_A ({data_A.shape[0]}) and distances_B ({distances_B.shape[0]})"
-                + f" do not match."
+                + " do not match."
             )
         self.nparams = self.nfeatures_A if params_groups is None else len(params_groups)
 
@@ -281,7 +282,8 @@ class DiffImbalance:
         self.mask = None
 
         self.state = None
-        self._distance_A = _compute_dist2_matrix_scaling  # TODO: assign other functions if other distances d_A are chosen
+        # TODO: assign other functions if other distances d_A are chosen
+        self._distance_A = _compute_dist2_matrix_scaling
 
         # generic checks and warnings
         assert self.nrows >= batches_per_epoch, (
@@ -290,19 +292,20 @@ class DiffImbalance:
         )
         assert (
             self.k_init is not None and self.k_final is not None
-        ), f"Provide values of 'k_init' and 'k_final' to compute lambda adaptively."
+        ), "Provide values of 'k_init' and 'k_final' to compute lambda adaptively."
         if self.k_init > 100:
             warnings.warn(
                 f"For efficiency reasons the maximum value for 'k_init' is 100, while you set it to {self.k_init}.\n"
-                + f"The run will continue with 'k_init = 100'"
+                + "The run will continue with 'k_init = 100'",
+                stacklevel=2,
             )
             self.k_init = 100
         assert (
             self.k_init >= self.k_final and self.k_final > 0
-        ), f"'k_init' and 'k_final' must satisfy: k_init >= k_final >= 1."
+        ), "'k_init' and 'k_final' must satisfy: k_init >= k_final >= 1."
         assert isinstance(k_init, int) and isinstance(
             k_final, int
-        ), f"'k_init' and 'k_final' must be positive integers."
+        ), "'k_init' and 'k_final' must be positive integers."
         if self.params_groups is not None:
             n_vars = np.sum(self.params_groups)
             assert n_vars == self.nfeatures_A, (
@@ -333,9 +336,9 @@ class DiffImbalance:
         else:
             self.lambda_method = self._compute_adapt_lambda
 
-    def _create_functions(self):
+    def _create_functions(self):  # noqa: C901
         def _compute_rank_matrix(batch_rows, batch_columns, periods):
-            """Computes the matrix of ranks for the target space B.
+            """Compute the matrix of ranks for the target space B.
 
             Args:
                 batch_rows (jnp.array(float)): matrix of shape (n_points_rows, n_features_B), containing
@@ -362,7 +365,7 @@ class DiffImbalance:
             return rank_matrix
 
         def _cosine_decay_func(start_value, final_value, step):
-            """Implements a cosine decay during the training.
+            """Implement a cosine decay during the training.
 
             The arguments start_value and final_value can be values of the learning rate or of the
             neighbor order used to compute lambda in the adaptive and point-adaptive schemes.
@@ -381,7 +384,7 @@ class DiffImbalance:
             return cosine
 
         def _compute_point_adapt_lambdas(dist2_matrix, step=None, k=None):
-            """Computes lambda parameters with the point-adaptive scheme, according to the current value of k.
+            """Compute lambda parameters with the point-adaptive scheme, according to the current value of k.
 
             Args:
                 dist2_matrix (jnp.array(float)): matrix of shape (n_points_rows, n_points_columns), containing
@@ -411,13 +414,13 @@ class DiffImbalance:
             current_lambdas = -smallest_dist2[:, current_k - 1] * self.lambda_factor
 
             # DON'T DELETE: Adaptive scheme of cython code
-            # diffs_dists_2nd_1st = -smallest_dist2[:, 1] + smallest_dist2[:, 0]
-            # current_lambdas = 0.5*(diffs_dists_2nd_1st.min() + diffs_dists_2nd_1st.mean())
+            # diffs_dists_2nd_1st = -smallest_dist2[:, 1] + smallest_dist2[:, 0]  # noqa: E800
+            # current_lambdas = 0.5*(diffs_dists_2nd_1st.min() + diffs_dists_2nd_1st.mean())  # noqa: E800
 
             return current_lambdas
 
         def _compute_adapt_lambda(dist2_matrix, step=None, k=None):
-            """Computes smoothing parameter lambda with adaptive scheme.
+            """Compute smoothing parameter lambda with adaptive scheme.
 
             Args:
                 dist2_matrix (jnp.array(float)): matrix of shape (n_points_rows, n_points_columns), containing
@@ -439,7 +442,7 @@ class DiffImbalance:
         def _compute_training_diff_imbalance(
             params, batch_A_rows, batch_A_columns, batch_B_ranks, step
         ):
-            """Computes the Differentiable Information Imbalance (DII) at the current step of the training.
+            """Compute the Differentiable Information Imbalance (DII) at the current step of the training.
 
             Args:
                 params (jnp.array(float)): array of shape (n_features_A,) of the current feature weights.
@@ -483,29 +486,29 @@ class DiffImbalance:
             )
 
             # DON'T DELETE: Alternative definition of c_ij coefficients (sigmoid instead of softmax)
-            # c_matrix = jax.nn.sigmoid(
-            #    (lambdas[:, jnp.newaxis] - dist2_matrix_A)/(self.lambda_factor * lambdas[:, jnp.newaxis])
-            # )
+            # c_matrix = jax.nn.sigmoid(  # noqa: E800
+            #    (lambdas[:, jnp.newaxis] - dist2_matrix_A)/(self.lambda_factor * lambdas[:, jnp.newaxis])  # noqa: E800
+            # )  # noqa: E800
 
             # compute DII
             conditional_ranks = jnp.sum(batch_B_ranks * c_matrix, axis=1)
             diff_imbalance = 2.0 / (max_rank + 1) * jnp.sum(conditional_ranks) / N
 
-            # DON'T DELETE: analytical gradient of the DII (without differentiating lambda)
-            # diffs_squared = ((batch_A_rows[:,jnp.newaxis,:] - batch_A_columns[jnp.newaxis,:,:])
-            #                *(batch_A_rows[:,jnp.newaxis,:] - batch_A_columns[jnp.newaxis,:,:])) # shape (nrows, ncols, D)
-            # second_term = (c_matrix[:,:,jnp.newaxis] * diffs_squared).sum(axis=1, keepdims=True)
-            # grad_imbalance = (
-            #    4.0 * params / (N * (self.max_rank + 1))
+            # DON'T DELETE: analytical gradient of the DII (without differentiating lambda)  # noqa: E800
+            # diffs_squared = ((batch_A_rows[:,jnp.newaxis,:] - batch_A_columns[jnp.newaxis,:,:])  # noqa: E800,E501
+            #                *(batch_A_rows[:,jnp.newaxis,:] - batch_A_columns[jnp.newaxis,:,:])) # shape (nrows, ncols, D)  # noqa: E800,E501
+            # second_term = (c_matrix[:,:,jnp.newaxis] * diffs_squared).sum(axis=1, keepdims=True)  # noqa: E800
+            # grad_imbalance = (  # noqa: E800
+            #    4.0 * params / (N * (self.max_rank + 1))  # noqa: E800
             #    * jnp.sum((batch_B_ranks * c_matrix)[:,:,jnp.newaxis] / lambdas[:,jnp.newaxis,jnp.newaxis]
             #    * (-diffs_squared + second_term), axis=(0,1))
-            # )
+            # )  # noqa: E800
             return diff_imbalance
 
         def _compute_final_diff_imbalance_and_error(
             params, batch_A_rows, batch_A_columns, batch_B_ranks, k
         ):
-            """Computes the Differentiable Information Imbalance (DII) and its error.
+            """Compute the Differentiable Information Imbalance (DII) and its error.
 
             Args:
                 params (jnp.array(float)): array of shape (n_features_A,) of the current feature weights.
@@ -542,11 +545,11 @@ class DiffImbalance:
             )
 
             # DON'T DELETE: compute standard Information Imbalance
-            # batch_A_ranks = dist2_matrix_A.argsort(axis=1).argsort(axis=1) + 1
-            # mask_A = (batch_A_ranks <= k)
-            # conditional_ranks = jnp.where(mask_A, 1.0, 0.0) * batch_B_ranks
-            # conditional_ranks = conditional_ranks.sum(axis=-1) / k
-            # values_average = 2.0 / (max_rank + 1) * conditional_ranks
+            # batch_A_ranks = dist2_matrix_A.argsort(axis=1).argsort(axis=1) + 1  # noqa: E800
+            # mask_A = (batch_A_ranks <= k)  # noqa: E800
+            # conditional_ranks = jnp.where(mask_A, 1.0, 0.0) * batch_B_ranks  # noqa: E800
+            # conditional_ranks = conditional_ranks.sum(axis=-1) / k  # noqa: E800
+            # values_average = 2.0 / (max_rank + 1) * conditional_ranks  # noqa: E800
 
             # compute DII and error
             values_average = (
@@ -560,7 +563,7 @@ class DiffImbalance:
         def _compute_final_diff_imbalance(
             params, batch_A_rows, batch_A_columns, batch_B_ranks, k
         ):
-            """Computes the Differentiable Information Imbalance (DII) without providing the error.
+            """Compute the Differentiable Information Imbalance (DII) without providing the error.
 
             Args:
                 params (jnp.array(float)): array of shape (n_features_A,) of the current feature weights.
@@ -609,7 +612,7 @@ class DiffImbalance:
             return diff_imbalance
 
         def _train_step(state, batch_A_rows, batch_A_columns, batch_B_ranks):
-            """Performs a single gradient descent step in the optimization of the DII.
+            """Perform a single gradient descent step in the optimization of the DII.
 
             Args:
                 state (flax.training.train_state.TrainState object): current training state.
@@ -624,13 +627,15 @@ class DiffImbalance:
                 state_new (flax.training.train_state.TrainState object): new training state after optimizer step
                 imb (flat): new value of the DII after optimizer step.
             """
-            loss_fn = lambda params: _compute_training_diff_imbalance(
-                params=params,
-                batch_A_rows=batch_A_rows,
-                batch_A_columns=batch_A_columns,
-                batch_B_ranks=batch_B_ranks,
-                step=state.step,
-            )
+            def loss_fn(params):
+                return _compute_training_diff_imbalance(
+                    params=params,
+                    batch_A_rows=batch_A_rows,
+                    batch_A_columns=batch_A_columns,
+                    batch_B_ranks=batch_B_ranks,
+                    step=state.step,
+                )
+
             # Get loss and gradient
             imb, grads = jax.value_and_grad(loss_fn)(state.params)
 
@@ -654,14 +659,14 @@ class DiffImbalance:
                 )
 
                 # DON'T DELETE: Soft version of GD clipping
-                # candidate_params = (
+                # candidate_params = (  # noqa: E800
                 #    state.params
-                #    - jnp.sign(state.params) * current_lr * self.l1_strength
-                # )
-                # state = state.replace(
-                #    params=state.params
+                #    - jnp.sign(state.params) * current_lr * self.l1_strength  # noqa: E800
+                # )  # noqa: E800
+                # state = state.replace(  # noqa: E800
+                #    params=state.params  # noqa: E800
                 #    * (1.0 - jnp.where(state.params * candidate_params < 0, 1.0, 0.0))
-                # )
+                # )  # noqa: E800
 
                 # Scale weight vector to original norm
                 norm_now = jnp.sqrt((state.params**2).sum())
@@ -683,7 +688,7 @@ class DiffImbalance:
         self._train_step = jax.jit(_train_step)
 
     def _return_mask(self, npoints, discard_close_ind):
-        """Returns a square boolean mask with False on the diagonals, and True elsewhere.
+        """Return a square boolean mask with False on the diagonals, and True elsewhere.
 
         Args:
             npoints (int): number of rows and columns of the mask matrix.
@@ -719,7 +724,7 @@ class DiffImbalance:
 
     def _return_nn_indices(self, discard_close_ind=0):
         """
-        Returns indices of the nearest neighbor of each point.
+        Return indices of the nearest neighbor of each point.
 
         Args:
             discard_close_ind (int): given any point i, defines the "close" points (following the labelling order
@@ -755,7 +760,7 @@ class DiffImbalance:
         return nn_indices
 
     def _train_epoch(self, key):
-        """Performs the training for a single epoch.
+        """Perform the training for a single epoch.
 
         Args:
             key (jax.random.PRNGKey): key for the JAX pseudo-random number generator (PRNG).
@@ -784,18 +789,18 @@ class DiffImbalance:
                 )
             # DON'T DELETE: Alternative method for mini-batch GD (only subsample rows)
             # for i_batch, batch_indices in enumerate(all_batch_indices):
-            #    ordered_column_indices = np.ravel(
-            #        np.delete(all_batch_indices, i_batch, axis=0)
-            #    )
-            #    ordered_column_indices = np.append(
+            #    ordered_column_indices = np.ravel(  # noqa: E800
+            #        np.delete(all_batch_indices, i_batch, axis=0)  # noqa: E800
+            #    )  # noqa: E800
+            #    ordered_column_indices = np.append(  # noqa: E800
             #        batch_indices, ordered_column_indices
-            #    )
+            #    )  # noqa: E800
             #    self.state, imb = self._train_step(
             #        self.state,
-            #        self.data_A_rows[batch_indices],
-            #        self.data_A_columns[ordered_column_indices],
-            #        self.ranks_B[batch_indices][:, ordered_column_indices],
-            #    )
+            #        self.data_A_rows[batch_indices],  # noqa: E800
+            #        self.data_A_columns[ordered_column_indices],  # noqa: E800
+            #        self.ranks_B[batch_indices][:, ordered_column_indices],  # noqa: E800
+            #    )  # noqa: E800
 
         # -----------------------------BATCH GD----------------------------
         else:
@@ -813,7 +818,7 @@ class DiffImbalance:
         return self.state.params, imb
 
     def _init_optimizer(self):
-        """Initializes the optimizer and the training state using the Optax library.
+        """Initialize the optimizer and the training state using the Optax library.
 
         The function uses the attribute optimizer_name of the DiffImbalance object,
         which can be set to one of the following options: "sgd", "adam", "adamw". For more
@@ -846,7 +851,8 @@ class DiffImbalance:
             self.lr_schedule = optax.constant_schedule(value=self.learning_rate)
         else:
             raise ValueError(
-                f'Unknown learning rate decay schedule "{self.learning_rate_decay}". Choose among None, "cos" and "exp".'
+                f'Unknown learning rate decay schedule "{self.learning_rate_decay}". '
+                'Choose among None, "cos" and "exp".'
             )
         optimizer = opt_class(self.lr_schedule)
 
@@ -858,7 +864,7 @@ class DiffImbalance:
         )
 
     def train(self, bar_label=None):
-        """Performs the full training of the DII, using the input attributes of the DiffImbalance object.
+        """Perform the full training of the DII, using the input attributes of the DiffImbalance object.
 
         Notice that when mini-batches are employed, for efficiency reasons the DII is *not* recomputed
         over the full data set at each training epoch. To access the value of the DII over the full data
@@ -893,13 +899,13 @@ class DiffImbalance:
             step=0,
         )
         # DON'T DELETE: Alternative method for mini-batching (only sample rows)
-        # imb_start = self._compute_training_diff_imbalance(
-        #    params=self.params_init,
-        #    batch_A_rows=self.data_A_rows[batch_indices],
-        #    batch_A_columns=self.data_A_columns,
-        #    batch_B_ranks=self.ranks_B[batch_indices],
-        #    step=0,
-        # )
+        # imb_start = self._compute_training_diff_imbalance(  # noqa: E800
+        #    params=self.params_init,  # noqa: E800
+        #    batch_A_rows=self.data_A_rows[batch_indices],  # noqa: E800
+        #    batch_A_columns=self.data_A_columns,  # noqa: E800
+        #    batch_B_ranks=self.ranks_B[batch_indices],  # noqa: E800
+        #    step=0,  # noqa: E800
+        # )  # noqa: E800
         params_training = params_training.at[0].set(jnp.abs(self.params_init))
         imbs_training = imbs_training.at[0].set(imb_start)
 
@@ -918,10 +924,10 @@ class DiffImbalance:
 
         return np.array(params_training), np.array(imbs_training)
 
-    def return_final_dii(
+    def return_final_dii(  # noqa: C901
         self, compute_error=True, ratio_rows_columns=1, seed=0, discard_close_ind=0
     ):
-        """Returns final DII computed over the full data set using the optimal weights.
+        """Return final DII computed over the full data set using the optimal weights.
 
         If the training was carried out with mini-batches of small size, this method allows computing a better
         estimate of the DII than the final DII value produced by 'train'.
@@ -958,16 +964,17 @@ class DiffImbalance:
         assert self.params_final is not None, "First call the train() method!"
         if compute_error is True and ratio_rows_columns is None:
             raise ValueError(
-                "Option 'compute_error==True' requires a value for the argument 'ratio_rows_columns'."
+                "Option 'compute_erroris True' requires a value for the argument 'ratio_rows_columns'."
             )
         elif compute_error is False and ratio_rows_columns is not None:
             warnings.warn(
-                f"You set 'compute_error' to False; argument 'ratio_rows_columns' will be ignored.\n"
-                + f"To suppress this warning set it to None."
+                "You set 'compute_error' to False; argument 'ratio_rows_columns' will be ignored.\n"
+                + "To suppress this warning set it to None.",
+                stacklevel=2,
             )
 
         # case 1: compute final DII and its error, using different points for rows and columns
-        if compute_error == True:
+        if compute_error is True:
             # subsample data to remove neighbor correlations, with stride discard_close_ind+1
             data_A = self.data_A
             data_B = self.data_B
@@ -1024,7 +1031,7 @@ class DiffImbalance:
             )
 
         # case 2: compute final DII only (square distance matrices)
-        elif compute_error == False:
+        elif compute_error is False:
             # construct mask to discard distances d[i, i-discard_close_ind:i+discard_close_ind+1], for each i
             mask = None
             self.mask = None
@@ -1071,7 +1078,7 @@ class DiffImbalance:
 
         return imb_final, error_final
 
-    def forward_greedy_feature_selection(
+    def forward_greedy_feature_selection(  # noqa: C901
         self,
         n_features_max=None,
         n_best=10,
@@ -1080,7 +1087,7 @@ class DiffImbalance:
         seed=0,
         discard_close_ind=0,
     ):
-        """Performs forward greedy feature selection using the Differentiable Information Imbalance.
+        """Perform forward greedy feature selection using the Differentiable Information Imbalance.
 
         Starting with all individual features, the algorithm evaluates which single feature has
         the lowest DII. Then it combines the best n_best single features with each
@@ -1108,10 +1115,12 @@ class DiffImbalance:
             best_weights_list (list): list of arrays containing the optimal weights for each set of selected features.
         """
         if self.l1_strength != 0.0:
-            warnings.warn(f"The greedy search will run with l1 strength equal to 0.")
+            warnings.warn(
+                "The greedy search will run with l1 strength equal to 0.", stacklevel=2
+            )
         assert (
             self.params_groups is None
-        ), f"This method is not yet compatible with option 'params_groups'."
+        ), "This method is not yet compatible with option 'params_groups'."
         n_features = self.nfeatures_A
         if n_features_max is None:
             n_features_max = n_features
@@ -1122,7 +1131,7 @@ class DiffImbalance:
         best_errors = []
         best_weights_list = []
 
-        ############################ First evaluate all single features ############################
+        # First evaluate all single features ############################
         single_feature_diis = []
         single_feature_errors = []
 
@@ -1240,7 +1249,7 @@ class DiffImbalance:
         # Get all features as a list
         all_features = list(range(n_features))
 
-        ############################ Greedy loop over n-tuples (n>1) ############################
+        # Greedy loop over n-tuples (n>1) ############################
         while len(best_feature_sets[-1]) < min(n_features_max, n_features):
             candidate_features = []
             candidate_diis = []
@@ -1402,7 +1411,7 @@ class DiffImbalance:
                 print(
                     f"Training failed for best feature set {candidate_features[best_idx]}: {str(e)}"
                 )
-                print(f"Using zero weights for this iteration...")
+                print("Using zero weights for this iteration...")
                 best_weights = np.zeros(n_features)
 
             best_weights_list.append(best_weights)
@@ -1423,7 +1432,7 @@ class DiffImbalance:
 
         return best_feature_sets, best_diis, best_errors, best_weights_list
 
-    def backward_greedy_feature_selection(
+    def backward_greedy_feature_selection(  # noqa: C901
         self,
         n_features_min=1,
         n_best=10,
@@ -1432,7 +1441,7 @@ class DiffImbalance:
         seed=0,
         discard_close_ind=0,
     ):
-        """Performs backward greedy feature selection using the Differentiable Information Imbalance.
+        """Perform backward greedy feature selection using the Differentiable Information Imbalance.
 
         Starting with all features, the algorithm progressively removes the least informative features
         one at a time, until either no features are left or n_features_min is reached.
@@ -1461,10 +1470,12 @@ class DiffImbalance:
             best_weights_list (list): list of arrays containing the optimal weights for each set of selected features.
         """
         if self.l1_strength != 0.0:
-            warnings.warn(f"The greedy search will run with l1 strength equal to 0.")
+            warnings.warn(
+                "The greedy search will run with l1 strength equal to 0.", stacklevel=2
+            )
         assert (
             self.params_groups is None
-        ), f"This method is not yet compatible with option 'params_groups'."
+        ), "This method is not yet compatible with option 'params_groups'."
         assert self.params_final is not None, "First call the train() method!"
 
         n_features = self.nfeatures_A
@@ -1478,7 +1489,7 @@ class DiffImbalance:
         # Start with all features and use the original trained weights
         current_features = [list(range(n_features))]
 
-        ############################ First evaluate all features together ############################
+        # First evaluate all features together ############################
         if compute_error:
             self.return_final_dii(
                 compute_error=True,
@@ -1508,7 +1519,7 @@ class DiffImbalance:
         feature_sets.append(current_features[0].copy())
         best_weights_list.append(self.params_final)
 
-        ############################ Greedy loop over n-tuples (n<D) ############################
+        # Greedy loop over n-tuples (n<D) ############################
         while feature_sets[-1] and len(feature_sets[-1]) > n_features_min:
             candidate_diis = []
             candidate_errors = []
@@ -1520,7 +1531,7 @@ class DiffImbalance:
                     # Skip sets that are already at minimum size
                     continue
 
-                for i, feature in enumerate(selected_set):
+                for i, _feature in enumerate(selected_set):
                     # Create candidate feature set by removing this feature
                     candidate_set = selected_set.copy()
                     candidate_set.pop(i)
@@ -1672,7 +1683,7 @@ class DiffImbalance:
                 print(
                     f"Training failed for best feature set {best_feature_set}: {str(e)}"
                 )
-                print(f"Using zero weights for this iteration...")
+                print("Using zero weights for this iteration...")
                 best_weights = np.zeros(n_features)
 
             best_weights_list.append(best_weights)

--- a/dadapy/feature_weighting.py
+++ b/dadapy/feature_weighting.py
@@ -45,9 +45,10 @@ from dadapy.base import Base
 cores = multiprocessing.cpu_count()
 
 
+# TODO: remove when this works with different maxk
 def check_maxk(func):
     """Warn once that maxk is not yet supported by FeatureWeighting and reset it."""
-    # TODO: remove when this works with different maxk
+
     @wraps(func)
     def with_check(*args, **kwargs):
         feature_selector: type[FeatureWeighting] = args[0]

--- a/dadapy/feature_weighting.py
+++ b/dadapy/feature_weighting.py
@@ -46,6 +46,7 @@ cores = multiprocessing.cpu_count()
 
 
 def check_maxk(func):
+    """Warn once that maxk is not yet supported by FeatureWeighting and reset it."""
     # TODO: remove when this works with different maxk
     @wraps(func)
     def with_check(*args, **kwargs):
@@ -64,6 +65,8 @@ def check_maxk(func):
 
 
 class FeatureWeighting(Base):
+    """Feature weighting via the Differentiable Information Imbalance."""
+
     def __init__(
         self,
         coordinates=None,
@@ -73,6 +76,7 @@ class FeatureWeighting(Base):
         verbose=False,
         n_jobs=cores,
     ):
+        """Initialise the FeatureWeighting object."""
         super().__init__(
             coordinates=coordinates,
             distances=distances,
@@ -92,6 +96,7 @@ class FeatureWeighting(Base):
 
     @property
     def full_distance_matrix(self):
+        """Return the full pairwise distance matrix, computing it lazily on first access."""
         if self._full_distance_matrix is None:
             self._full_distance_matrix = _return_full_dist_matrix(
                 data=self.X,
@@ -164,8 +169,10 @@ class FeatureWeighting(Base):
 
     @check_maxk
     def return_optimal_lambda(self, fraction: float = 1.0):
-        """Computes the optimal softmax scaling parameter lambda for the DII optimization.
+        """Compute the optimal softmax scaling parameter lambda for the DII optimization.
+
         This parameter represents a reasonable scale of distances of the data points in the input data set.
+
         Args:
             fraction (float): Zoom in or out from the optimal distance scale.
                 Default: 1.0. Suggested to keep it at default.
@@ -188,7 +195,8 @@ class FeatureWeighting(Base):
         decaying_lr: str = "exp",
         trial_learning_rates: np.ndarray = None,
     ):
-        """Find the optimal learning rate for the optimization of the DII by testing several on a reduced set
+        """Find the optimal learning rate for the optimization of the DII by testing several on a reduced set.
+
         Args:
             target_data: FeatureWeighting object, containing the
                 groundtruth data (D_groundtruth x N array, period (optional)) to be compared to.
@@ -200,7 +208,8 @@ class FeatureWeighting(Base):
             decaying_lr (string): Default: "exp".
                 "exp" for exponentially decaying learning rate (cut in half every 10 epochs):
                 lrate = l_rate_initial * 2**(-i_epoch/10),
-                or "cos" for cosine decaying learning rate: lrate = l_rate_initial * 0.5 * (1+ cos((pi * i_epoch)/n_epochs)).
+                or "cos" for cosine decaying learning rate:
+                lrate = l_rate_initial * 0.5 * (1+ cos((pi * i_epoch)/n_epochs)).
                 "static" for no decay in the learning rate.
             trial_learning_rates (np.ndarray or list or None): learning rates to try.
                 If None are given, a sensible set of learning rates is tested.
@@ -275,8 +284,9 @@ class FeatureWeighting(Base):
 
     @check_maxk
     def return_dii(self, target_data: Type[Base], lambd: float = None):
-        """Computes the DII between two FeatureWeighting objects based
-            on distances of input data and rank information of groundtruth data.
+        """Compute the DII between two FeatureWeighting objects.
+
+        Uses distances of input data and rank information of groundtruth data.
 
         Args:
             target_data: FeatureWeighting object,
@@ -313,8 +323,10 @@ class FeatureWeighting(Base):
     def return_dii_gradient(
         self, target_data: Type[Base], weights: np.ndarray, lambd: float = None
     ):
-        """Computes the gradient of the DII between two FeatureWeighting objects
-            (input object and ground truth object (= target_data)) with respect to the weights of the input features.
+        """Compute the gradient of the DII with respect to the weights of the input features.
+
+        The DII is computed between two FeatureWeighting objects (input object and ground truth
+        object (= target_data)).
 
         Args:
             target_data: FeatureWeighting object, containing the groundtruth data
@@ -370,8 +382,9 @@ class FeatureWeighting(Base):
         l1_penalty: float = 0.0,
         decaying_lr: str = "exp",
     ):
-        """Optimize the differentiable information imbalance using gradient descent
-            of the DII between input data object A and groundtruth data object B.
+        """Optimize the differentiable information imbalance using gradient descent.
+
+        Optimizes the DII between input data object A and groundtruth data object B.
 
         Args:
             target_data: FeatureWeighting object, containing the groundtruth data
@@ -394,7 +407,8 @@ class FeatureWeighting(Base):
             decaying_lr (string): Default: "exp".
                 "exp" for exponentially decaying learning rate (cut in half every 10 epochs):
                 lrate = l_rate_initial * 2**(-i_epoch/10),
-                or "cos" for cosine decaying learning rate: lrate = l_rate_initial * 0.5 * (1+ cos((pi * i_epoch)/n_epochs)).
+                or "cos" for cosine decaying learning rate:
+                lrate = l_rate_initial * 0.5 * (1+ cos((pi * i_epoch)/n_epochs)).
                 "static" for no decay in the learning rate.
         Returns:
             final_weights: np.ndarray, shape (D). Array of the optmized weights.
@@ -460,8 +474,10 @@ class FeatureWeighting(Base):
         constrain: bool = False,
         decaying_lr: str = "exp",
     ):
-        """Do a stepwise backward elimination of feature weights, always eliminating the lowest weight;
-            after each elimination the DII is optimized by gradient descent using the remaining features
+        """Do a stepwise backward elimination of feature weights.
+
+        Always eliminates the lowest weight; after each elimination the DII is optimized by
+        gradient descent using the remaining features.
 
         Args:
             target_data: FeatureWeighting object, containing the groundtruth data
@@ -476,7 +492,8 @@ class FeatureWeighting(Base):
             decaying_lr (string): Default: "exp".
                 "exp" for exponentially decaying learning rate (cut in half every 10 epochs):
                 lrate = l_rate_initial * 2**(-i_epoch/10),
-                or "cos" for cosine decaying learning rate: lrate = l_rate_initial * 0.5 * (1+ cos((pi * i_epoch)/n_epochs)).
+                or "cos" for cosine decaying learning rate:
+                lrate = l_rate_initial * 0.5 * (1+ cos((pi * i_epoch)/n_epochs)).
                 "static" for no decay in the learning rate.
 
         Returns:
@@ -582,7 +599,8 @@ class FeatureWeighting(Base):
         refine: bool = False,
         plotlasso: bool = True,
     ):
-        """Search the number of resulting non-zero weights and the optimized DII for several l1-regularization strengths
+        """Search non-zero-weight counts and optimized DII over several l1-regularization strengths.
+
         Args:
             target_data: FeatureWeighting object, containing the groundtruth data
                 (D_groundtruth x N array, period (optional)) to be compared to.
@@ -601,7 +619,8 @@ class FeatureWeighting(Base):
             decaying_lr (string): Default: "exp".
                 "exp" for exponentially decaying learning rate (cut in half every 10 epochs):
                 lrate = l_rate_initial * 2**(-i_epoch/10),
-                or "cos" for cosine decaying learning rate: lrate = l_rate_initial * 0.5 * (1+ cos((pi * i_epoch)/n_epochs)).
+                or "cos" for cosine decaying learning rate:
+                lrate = l_rate_initial * 0.5 * (1+ cos((pi * i_epoch)/n_epochs)).
                 "static" for no decay in the learning rate.
             refine (bool): default: False. If True, the l1-penalties are added in between penalties
                 where the number of non-zero weights changes by more than one.

--- a/dadapy/hamming.py
+++ b/dadapy/hamming.py
@@ -1,3 +1,5 @@
+"""Hamming distances and Binary Intrinsic Dimension (BID) estimation for Ising-like data."""
+
 import os
 from time import time
 
@@ -10,7 +12,7 @@ from jax import random
 from jax.scipy.special import gammaln
 from jax.tree_util import register_pytree_node
 
-# from jax.experimental.host_callback import call
+# from jax.experimental.host_callback import call  # noqa: E800
 
 jdevices("cpu")[0]  # to run JAX on CPU
 eps = 1e-7  # good old small epsilon
@@ -18,6 +20,8 @@ config.update("jax_enable_x64", True)  # enable jnp.float64 dtype
 
 
 class Hamming:
+    """Compute and store pairwise Hamming distances and their empirical histogram."""
+
     def __init__(
         self,
         q=2,  # number of states: 2 for binary spins. In the future we can think of extending this to q>2.
@@ -26,6 +30,7 @@ class Hamming:
         crossed_distances=0,  # 0 means we have one dataset with N samples and N(N-1)/2 (correlated) distances.
         verbose=True,  #
     ):
+        """Initialise the Hamming object."""
         self.q = q
         self.coordinates = coordinates
         self.distances = distances
@@ -45,9 +50,10 @@ class Hamming:
         sort=False,
         check_format=True,
     ):
-        """
-        Computes all to all distances in dataset and stores them
-        in the matrix "self.distances" of shape (Ns,Ns), where Ns is the number of samples
+        """Compute all-to-all distances in the dataset and store them.
+
+        Distances are stored in the matrix self.distances of shape (Ns,Ns), where Ns is
+        the number of samples.
         """
         if self.q == 2:
             self.distances = jcompute_distances(
@@ -67,9 +73,9 @@ class Hamming:
         resultsfolder="results/hist/",
         filename="counts.txt",
     ):
-        """
-        Given the computed distances, this routine computes the histogram (Pemp).
-        It defines
+        """Compute the empirical histogram (Pemp) of the previously computed distances.
+
+        Defines:
         - self.D_values, a vector containing the sampled distances
         - self.D_counts, a vector containing how many times each distance was sampled
         - self.D_probs, self.counts normalized by the total number of counts observed.
@@ -108,13 +114,11 @@ class Hamming:
             self.D_probs = self.D_counts / np.sum(self.D_counts)
 
     def set_r_quantile(self, alpha, round=True, precision=10):
-        """
-        Defines
+        """Define self.r as the quantile of order alpha of self.D_probs.
 
-        - self.r as the quantile of order alpha of self.D_probs,
-        which can be used for rmax or rmin,
-        to discard distances larger than rmax or smaller than rmin, respectively.
-        - self.r_idx as the index of self.r in self.D_values
+        - self.r can be used for rmax or rmin, to discard distances larger than rmax or
+          smaller than rmin, respectively.
+        - self.r_idx is the index of self.r in self.D_values.
         """
         if round:
             alpha = np.round(alpha, precision)
@@ -130,14 +134,13 @@ class Hamming:
         return
 
     def compute_moments(self):
-        """
-        computes the empirical mean and variance of H.D_probs
-        """
+        """Compute the empirical mean and variance of H.D_probs."""
         self.D_mu_emp = np.dot(self.D_probs, self.D_values)
         self.D_var_emp = np.dot(self.D_probs, self.D_values**2) - self.D_mu_emp**2
 
 
 def check_data_format(X):
+    """Assert that X contains only -1/+1 spin values."""
     e1, e2 = np.unique(X)
     assert (
         e1 == -1 and e2 == 1
@@ -151,7 +154,10 @@ def jcompute_distances(
     check_format=True,
     sort=False,
 ):
-    """This routine works for Ising spins variables defined as +-1 (this is faster than scipy)"""
+    """Compute pairwise Hamming distances for Ising spin variables defined as +-1.
+
+    Faster than scipy for this input format.
+    """
     X1 = jnp.array(X1).astype(jnp.int32)
     X2 = jnp.array(X2).astype(jnp.int32)
 
@@ -189,9 +195,7 @@ def jcompute_distances(
 
 @jit
 def _jcompute_distances(idx, pytree):
-    """
-    for each data sample indexed by "sample_idx" (row), computes the distance between it and the rest
-    """
+    """Compute the distance between sample row ``idx`` and the rest of the data."""
     pytree["sample_idx"] = idx
     pytree = lax.cond(
         pytree["crossed_distances"], _set_lower_idx_true, _set_lower_idx_false, pytree
@@ -206,26 +210,20 @@ def _jcompute_distances(idx, pytree):
 
 
 def _set_lower_idx_true(pytree):
-    """
-    if we have two datasets, we have Ns1 * Ns2 distances to compute.
-    """
+    """Set lower bound to 0: with two datasets we have Ns1 * Ns2 distances to compute."""
     pytree["lower_idx"] = 0
     return pytree
 
 
 def _set_lower_idx_false(pytree):
-    """
-    if we have one dataset, we have Ns(Ns-1)/2 distances to compute (the upper triangular part of "distances")
-    """
+    """Set lower bound to sample_idx+1: with one dataset compute the upper triangle of distances."""
     pytree["lower_idx"] = pytree["sample_idx"] + 1
     return pytree
 
 
 @jit
 def compute_row_distances(_idx, pytree):
-    """
-    for each data sample indexed by "sample_idx", computes the distance between it and the rest
-    """
+    """Compute the distance between sample row ``sample_idx`` and the rest of the data."""
     pytree["D"] = (
         pytree["D"]
         .at[pytree["sample_idx"], _idx]
@@ -245,9 +243,7 @@ def compute_row_distances(_idx, pytree):
 
 
 class Optimizer:
-    """
-    Stochastic optimization
-    """
+    """Stochastic optimizer state for BID fitting."""
 
     def __init__(
         self,
@@ -257,20 +253,21 @@ class Optimizer:
         d1=0.0,  # slope
         d1_r=0.0,  # slope + random pertubation (*** used by compute_Pmodel instead of d1...)
         delta=0.0,  # optimization step size
-        KL=jnp.double(0.0),  # KL divergence between Pemp(r) and Pmodel(r)
+        KL=jnp.double(0.0),  # noqa: B008  KL divergence between Pemp(r) and Pmodel(r)
         KL_aux=jnp.inf,  # auxiliary variable to check when KL decreases
         remp=None,  # vector with empirical Hamming distances
         Pemp=None,  # vector with empirical probabilities
         Pmodel=None,  # vector with model probabilities
         Nsteps=0,  # Number of steps for the optimization
         accepted=0,  # Accepted moves
-        acc_ratio=jnp.double(1.0),  # Acceptance ratio
+        acc_ratio=jnp.double(1.0),  # noqa: B008  Acceptance ratio
         save_logKLs_flag=0,  # Flag to save logKLs during optimization
         logKLs=None,  # Vector with logKLs during optimization
         idx=0,  # Auxiliary index
         mod_divisor=0,  # Auxiliary variable to export the log KL
         Nsteps_max=1000,  # Total number of saved steps (subsample of the total number of steps)
     ):
+        """Initialise the Optimizer state."""
         self.key = key
         self.d0 = d0
         self.d0_r = d0_r
@@ -326,9 +323,7 @@ register_pytree_node(Optimizer, Optimizer._tree_flatten, Optimizer._tree_unflatt
 
 
 def _compute_Pmodel(idx, Op):
-    """
-    note that this routine uses Op.d0_r and Op.d1_r to compute Pmodel
-    """
+    """Compute Pmodel at index ``idx`` using Op.d0_r and Op.d1_r."""
     ID = Op.d0_r + Op.d1_r * Op.remp[idx]
     Op.Pmodel = Op.Pmodel.at[idx].set(
         jnp.exp(
@@ -338,12 +333,13 @@ def _compute_Pmodel(idx, Op):
             - ID * jnp.log(jnp.double(2))
         )
     )
-    #  call(lambda x: print(f'{x}'),Op.Pmodel[idx])
+    #  call(lambda x: print(f'{x}'),Op.Pmodel[idx])  # noqa: E800
     return Op
 
 
 @jit
 def compute_Pmodel(Op):
+    """Compute the full model probability vector for the current (d0_r, d1_r) and normalize it."""
     Op = lax.fori_loop(
         lower=0, upper=Op.Pmodel.shape[0], body_fun=_compute_Pmodel, init_val=Op
     )
@@ -353,6 +349,7 @@ def compute_Pmodel(Op):
 
 @jit
 def step(idx, Op):
+    """Perform a single Metropolis step of the BID optimization."""
     Op.key, subkey = random.split(Op.key, num=2)
     r = random.uniform(subkey, dtype=jnp.float64)
     Op.d0_r = Op.d0 * (1 + Op.delta * (r - jnp.double(0.5)))
@@ -373,12 +370,14 @@ def step(idx, Op):
 
 @jit
 def compute_KLd(Op):
+    """Compute the KL divergence between Pemp and Pmodel and store it in Op.KL."""
     Op.KL = jnp.sum(Op.Pemp * jnp.log(Op.Pemp / Op.Pmodel))
     return Op
 
 
 @jit
 def update_state(Op):
+    """Accept the current trial state into the optimizer."""
     Op.d0 = Op.d0_r
     Op.d1 = Op.d1_r
     Op.KL_aux = Op.KL
@@ -388,11 +387,13 @@ def update_state(Op):
 
 @jit
 def do_nothing(Op):
+    """Return the optimizer unchanged (no-op branch for lax.cond)."""
     return Op
 
 
 @jit
 def save_logKL(Op):
+    """Append the current log(KL) to Op.logKLs."""
     Op.logKLs = Op.logKLs.at[Op.idx].set(jnp.log(Op.KL))
     Op.idx += 1
     return Op
@@ -400,6 +401,7 @@ def save_logKL(Op):
 
 @jit
 def minimize_KL(Op):
+    """Run the BID KL-minimization loop and return the updated optimizer state."""
     Op.logKLs = jnp.empty(shape=(Op.Nsteps_max), dtype=jnp.double)
     Op.mod_divisor = Op.Nsteps // Op.Nsteps_max
 
@@ -415,17 +417,19 @@ def minimize_KL(Op):
 
 
 class BID:
+    """Binary Intrinsic Dimension (BID) estimator built on a Hamming distance histogram."""
+
     def __init__(
         self,
-        H=Hamming(),  # instance of Hamming class defined above
+        H=Hamming(),  # noqa: B008  instance of Hamming class defined above
         Op=None,  # instance of Optimizer class defined above
         alphamin=0.0,
         alphamax=0.2,
         seed=1,
-        d0=jnp.double(0),  # BID \equiv d(r=0)  (see paper)
-        d1=jnp.double(0),  # slope of d(r) at r=0
-        d00=jnp.double(0),  # initial value of d0
-        d10=jnp.double(0),  # initial value of d1
+        d0=jnp.double(0),  # noqa: B008  BID \equiv d(r=0)  (see paper)
+        d1=jnp.double(0),  # noqa: B008  slope of d(r) at r=0
+        d00=jnp.double(0),  # noqa: B008  initial value of d0
+        d10=jnp.double(0),  # noqa: B008  initial value of d1
         delta=5e-4,
         Nsteps=1e6,
         optfolder0="results/opt/",
@@ -435,6 +439,7 @@ class BID:
         export_logKLs=0,  # To export the curve of logKLs during optimization
         L=0,  # Number of bits / Ising spins
     ):
+        """Initialise the BID estimator."""
         self.H = H
         self.Op = Op
         self.alphamin = alphamin
@@ -464,12 +469,14 @@ class BID:
     def load_initial_condition(
         self,
     ):
+        """Load initial d0/d1 values from a previously saved optimization result."""
         self.set_filepaths()
         _, self.d00, self.d10, _ = self.load_results()
 
     def set_filepaths(
         self,
     ):
+        """Build the paths used to save and load the optimization results."""
         self.optfolder = self.optfolder0
         self.optfolder += f"alphamin{self.alphamin:.5f}/"
         self.optfolder += f"alphamax{self.alphamax:.5f}/"
@@ -483,6 +490,7 @@ class BID:
     def set_idmin(
         self,
     ):
+        """Set the lower index/cut-off rmin for the distance histogram."""
         if self.regularize is False:
             self.idmin = 0
             self.rmin = self.H.D_values[0]
@@ -496,6 +504,7 @@ class BID:
     def set_idmax(
         self,
     ):
+        """Set the upper index/cut-off rmax for the distance histogram."""
         self.H.set_r_quantile(self.alphamax)
         self.rmax = self.H.r
         self.idmax = self.H.r_idx
@@ -503,6 +512,7 @@ class BID:
         self.H.r_idx = None
 
     def truncate_hist(self):
+        """Truncate the empirical distance histogram to the [idmin, idmax] range."""
         self.remp = jnp.array(
             self.H.D_values[self.idmin : self.idmax + 1], dtype=jnp.float64
         )
@@ -513,6 +523,7 @@ class BID:
         self.Pmodel = jnp.zeros(shape=self.Pemp.shape, dtype=jnp.float64)
 
     def test_initial_condition(self, d0, d1):
+        """Evaluate the KL divergence for a candidate (d0, d1) initial condition."""
         self.Op.d0_r = jnp.double(d0)
         self.Op.d1_r = jnp.double(d1)
         self.Op = compute_Pmodel(self.Op)
@@ -520,6 +531,7 @@ class BID:
         return np.log(self.Op.KL)
 
     def set_initial_condition(self, d00min=0.05, d00max=0.95, d00step=0.05):
+        """Pick initial (d0, d1) by scanning a list of candidates and keeping the best."""
         # our home-made guess:
         d00_guess_list = jnp.array([jnp.double(self.Op.remp[-1])])
         d10_guess_list = jnp.array([jnp.double(1)])
@@ -545,10 +557,10 @@ class BID:
                     d10_guess_list[i],
                 )
             )
-        # print(f'{logKLs0=}')
+        # print(f'{logKLs0=}')  # noqa: E800
         i0 = jnp.nanargmin(logKLs0)
-        # print(f'{i0=}')
-        # print(f'{logKLs0[i0]=}')
+        # print(f'{i0=}')  # noqa: E800
+        # print(f'{logKLs0[i0]=}')  # noqa: E800
         self.d00 = d00_guess_list[i0]  # ; print(f'{self.d00=}')
         self.d10 = d10_guess_list[i0]  # ; print(f'{self.d10=}')
         self.Op.d0 = self.d00
@@ -558,6 +570,7 @@ class BID:
     def computeBID(
         self,
     ):
+        """Run the full BID estimation pipeline and optionally export the results."""
         self.set_idmin()
         self.set_idmax()
         self.truncate_hist()
@@ -613,17 +626,20 @@ class BID:
     def load_results(
         self,
     ):
+        """Load the saved (acceptance, d0, d1, logKL) record from optfile."""
         self.set_filepaths()
         return np.loadtxt(self.optfile, unpack=True, delimiter=",")
 
     def load_fit(
         self,
     ):
+        """Load the saved (remp, Pemp, Pmodel) model-validation record from valfile."""
         self.set_filepaths()
         return np.loadtxt(self.valfile, unpack=True)
 
     def load_logKLs_opt(
         self,
     ):
+        """Load the saved logKL trace from KLfile."""
         self.set_filepaths()
         return np.loadtxt(self.KLfile)

--- a/dadapy/kstar.py
+++ b/dadapy/kstar.py
@@ -19,15 +19,11 @@ The *kstar* module contains the *KStar* class.
 The computation of the optimal neighbourhood size (k*) is implemented in this class as the compute_kstar method.
 """
 
-import math
 import multiprocessing
 import time
 import warnings
 
 import numpy as np
-from scipy.special import gammaln
-from scipy.stats import chi2
-from tqdm import tqdm
 
 from dadapy._cython import cython_density as cd
 from dadapy.id_estimation import IdEstimation
@@ -90,7 +86,8 @@ class KStar(IdEstimation):
         # raise warning if self.intrinsic_dim is None using the warning module
         if self.intrinsic_dim is None:
             warnings.warn(
-                "Setting the k value but, be careful: the intrinsic dimension is not defined!"
+                "Setting the k value but, be careful: the intrinsic dimension is not defined!",
+                stacklevel=2,
             )
 
         if isinstance(k, np.ndarray):
@@ -104,15 +101,19 @@ class KStar(IdEstimation):
         """Compute an optimal choice of the neighbourhood size k for each point.
 
         Args:
-            alpha (float): Likelihood ratio parameter used to compute optimal k, i.e. quantile for the unfirm density likelihood-ratio test.
-            bonferroni_deloc (bool): apply bonferroni correction for multiple testing across the dataset
-            bonferroni_loc (bool): apply bonferroni correction for multiple testing correcting the threshold at each iteration
+            alpha (float): Likelihood ratio parameter used to compute optimal k, i.e. quantile
+                for the unfirm density likelihood-ratio test.
+            bonferroni_deloc (bool): apply bonferroni correction for multiple testing across
+                the dataset
+            bonferroni_loc (bool): apply bonferroni correction for multiple testing correcting
+                the threshold at each iteration
 
         """
         if self.intrinsic_dim is None:
             warnings.warn(
                 "Careful! The intrinsic dimension is not defined. "
-                "Computing it unsupervisedly with 'compute_id_2NN()' method"
+                "Computing it unsupervisedly with 'compute_id_2NN()' method",
+                stacklevel=2,
             )
             _ = self.compute_id_2NN()
 

--- a/dadapy/metric_comparisons.py
+++ b/dadapy/metric_comparisons.py
@@ -762,61 +762,6 @@ class MetricComparisons(Base):
 
         return overlaps
 
-    def return_label_overlap_coords(self, labels, coords, k=30):
-        """Return the neighbour overlap between a selection of coordinates and a set of labels.
-
-        An overlap of 1 means that all neighbours of a point have the same label as the central point.
-
-        Args:
-            labels (np.ndarray): the labels with respect to which the overlap is computed
-            coords (list(int)): a list of coordinates to consider for the distance computation
-            k (int): the number of neighbours considered for the overlap
-
-        Returns:
-            (float): the neighbour overlap of the points
-        """
-        raise AssertionError(
-            """This function is outdated and will be removed in a future version of the package. \
-        Use "return_label_overlap" instead."""
-        )
-
-    def return_overlap_coords(self, coords1, coords2, k=30):
-        """Return the neighbour overlap between two subspaces defined by two sets of coordinates.
-
-        An overlap of 1 means that in the two subspaces all points have an identical neighbourhood.
-
-        Args:
-            coords1 (list(int)): the list of coordinates defining the first subspace
-            coords2 (list(int)): the list of coordinates defining the second subspace
-            k (int): the number of neighbours considered for the overlap
-
-        Returns:
-            (float): the neighbour overlap of the two subspaces
-        """
-        raise AssertionError(
-            """This function is a wrong implementation of the overlap between two \
-            sets of coordinates and will be removed in a future version of the package. \
-            Use "return_data_overlap" instead."""
-        )
-
-    def return_label_overlap_selected_coords(self, labels, coord_list, k=30):
-        """Return a list of neighbour overlaps computed on a list of selected coordinates.
-
-        An overlap of 1 means that all neighbours of a point have the same label as the central point.
-
-        Args:
-            labels (np.ndarray): the labels with respect to which the overlap is computed
-            coord_list (list(list(int))): a list of lists, with each sublist representing a set of coordinates
-            k: the number of neighbours considered for the overlap
-
-        Returns:
-            (list(float)): a list of neighbour overlaps of the points
-        """
-        raise AssertionError(
-            """This function is outdated and will be removed in a future version of the package. \
-        Use "return_label_overlap" instead."""
-        )
-
     def return_inf_imb_causality(
         self,
         cause_present,

--- a/dadapy/neigh_graph.py
+++ b/dadapy/neigh_graph.py
@@ -32,9 +32,10 @@ cores = multiprocessing.cpu_count()
 
 
 class NeighGraph(KStar):
-    """
-    Computes the directed neighbourhood graph (DNG) based on the kstar optimal neighbourhood selection and
-    other DNG-based quantities. Inherits from class KStar. The DNG is stored in nind_list and can be
+    """Compute the directed neighbourhood graph (DNG) and related DNG-based quantities.
+
+    The DNG is based on the kstar optimal neighbourhood selection. Inherits from class KStar.
+    The DNG is stored in nind_list and can be
     retrieved using the kstar (inherited from Kstar class) and nind_iptr attributes. Can compute and store
     distances and vector differences between nodes connected on the DNG. Can compute and store the number
     of points in common in the neighbourhoods of couples of nodes connected on the DNG. Can use the common
@@ -123,12 +124,11 @@ class NeighGraph(KStar):
     # ----------------------------------------------------------------------------------------------
 
     def compute_neigh_indices(self):
-        """
-        Compute indices of all couples [i,j] where j is a neighbour of i up to k*-th nearest (excluded).
+        """Compute indices of neighbour couples [i,j] up to the k*-th nearest neighbour.
+
         The couples of indices are stored in nind_list.
         Also compute and fill the attributes nspar (the 0-th shape of nind_list) nind_iptr.
         """
-
         if self.kstar is None:
             self.compute_kstar()
 
@@ -155,7 +155,6 @@ class NeighGraph(KStar):
         Distances are stored in the neigh_dists array.
 
         """
-
         if self.distances is None:
             self.compute_distances()
 
@@ -183,7 +182,6 @@ class NeighGraph(KStar):
         If the attribute neigh_dists is not assigned, invokes method compute_neigh_dists.
 
         """
-
         if self.neigh_dists is None:
             self.compute_neigh_dists()
 
@@ -229,14 +227,13 @@ class NeighGraph(KStar):
     # ----------------------------------------------------------------------------------------------
 
     def compute_common_neighs(self, comp_common_neighs_mat=False):
-        """Compute the common number of neighbours between the couple of points (i,j) such that j is
-        in the neighbourhod of i.
+        """Compute the number of common neighbours between point couples (i,j) on the DNG.
 
+        Here j is required to be in the neighbourhood of i.
         The numbers are stored in common_neighs_array.
         If the flag comp_common_neighs_mat has value True, also the symmetric matrix common_neighs_mat is computed.
 
         """
-
         # compute neighbour indices
         if self.nind_list is None:
             self.compute_neigh_indices()
@@ -263,10 +260,10 @@ class NeighGraph(KStar):
     # ----------------------------------------------------------------------------------------------
 
     def compute_neigh_similarity_index(self, method="jaccard"):
-        """
-        Compute an estimate of the overlaps between the neighbourhoods of the points connected by edges on the DNG,
-        with values from 0 to 1, and stores them in the neigh_similarity_index attribute. See also the documentation
-        for the neigh_similarity_index attribute for completeness.
+        """Estimate overlaps between neighbourhoods of points connected by edges on the DNG.
+
+        Values range from 0 to 1 and are stored in the neigh_similarity_index attribute.
+        See also the documentation for the neigh_similarity_index attribute for completeness.
 
         Args:
             method (str): currently implemented "jaccard", "geometric", "squared_geometric".
@@ -279,7 +276,6 @@ class NeighGraph(KStar):
             "geometric": p_1,2 = k_1,2 / sqrt(k_1 * k_2), i.e. the number of common points divided by the geometric mean
             "squared geometric": p_1,2 = (k_1,2)^2 / (k_1 * k_2), i.e. the square of the "geometric" version
         """
-
         # check or compute common_neighs
         if self.common_neighs_array is None:
             self.compute_common_neighs()
@@ -311,10 +307,9 @@ class NeighGraph(KStar):
     # ----------------------------------------------------------------------------------------------
 
     def compute_neigh_similarity_index_mat(self, method=None, sparse_mat=False):
-        """
-        Compute, for any couple (i,j) of points connected on the directed neighbourhood graph, an estimate of the
-        overlaps between the neighbourhoods of the points connected by edges on the DNG, with values from 0 to 1 and
-        stores them in the neigh_similarity_index_mat matrix attribute.
+        """Estimate overlaps between neighbourhoods for all couples (i,j) connected on the DNG.
+
+        Values range from 0 to 1 and are stored in the neigh_similarity_index_mat matrix attribute.
 
         Args:
             method (str): currently implemented "jaccard", "geometric", "squared_geometric".
@@ -330,7 +325,6 @@ class NeighGraph(KStar):
             sparse_mat (bool): if True, the matrix is returned in sparse format (scipy.sparse.lil_matrix). If False, it
             is returned in dense format (numpy.ndarray).
         """
-
         sec = time.time()
         # check if the neigh_similarity_index array exists
         if method is not None:

--- a/dadapy/plot.py
+++ b/dadapy/plot.py
@@ -18,9 +18,8 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy as sp
-from matplotlib import cm
 from matplotlib.collections import LineCollection
-from scipy import cluster
+from scipy import cluster  # noqa: F401  # registers scipy.cluster submodule
 from sklearn import manifold
 
 
@@ -60,7 +59,6 @@ def plot_ID_line_fit_estimation(Data, decimation=0.9, fraction_used=0.9):
     plt.xlabel("log(mu)")
     plt.ylabel("-log(1-F(mu))")
     plt.show()
-    # plt.savefig('ID_line_fit_plot.png')
 
 
 def plot_SLAn(Data, linkage="single"):
@@ -90,8 +88,7 @@ def plot_SLAn(Data, linkage="single"):
         print("ERROR: select a valid linkage criterion")
 
     fig, ax = plt.subplots(nrows=1, ncols=1)  # create figure & 1 axis
-    dn = sp.cluster.hierarchy.dendrogram(DD)
-    # fig.savefig('dendrogramm.png')  # save the figure to file
+    sp.cluster.hierarchy.dendrogram(DD)
     plt.show()
 
 
@@ -140,8 +137,6 @@ def plot_MDS(Data, cmap="viridis", savefig=""):
             c=cc,
             weight="bold",
         )
-    #    for i in range(Data.N_clusters):
-    #        ax.annotate(i, (out[i, 0], out[i, 1]))
     # Add edges
     rr = np.amax(Rho_bord_m)
     if rr > 0.0:
@@ -188,7 +183,7 @@ def plot_DecGraph(Data, savefig=""):
     plt.show()
 
 
-def get_dendrogram(Data, cmap="viridis", savefig="", logscale=True):
+def get_dendrogram(Data, cmap="viridis", savefig="", logscale=True):  # noqa: C901
     """Generate a visualisation of the topography computed with ADP.
 
     This visualisation fundamentally corresponds to a hierarchy of the clusters built
@@ -210,8 +205,6 @@ def get_dendrogram(Data, cmap="viridis", savefig="", logscale=True):
             to the logarithm of the population of the clusters instead of
             proportional to the population itself. In very unbalanced clusterings,
             it makes the dendrogram more human readable. The default is True.
-
-    Returns:
 
     """
     # Prepare some auxiliary lists
@@ -391,8 +384,6 @@ def plot_inf_imb_plane(imbalances, coord_list=None, labels=None):
         imbalance computations
         labels (list of strings, optional): Labels for the list of coordinates
 
-    Returns:
-
     """
     plt.figure(figsize=(5, 5))
     for i, (imb0, imb1) in enumerate(imbalances.T):
@@ -429,10 +420,7 @@ def plot_pdf(n_emp, n_mod, title=None, fileout=None):
         title (string, optional): title
         fileout (string, optional): path to save the plot
 
-    Returns:
-
     """
-
     sup = max(n_emp.max(), n_mod.max())
     inf = min(n_emp.min(), n_mod.min())
     a = np.histogram(
@@ -470,8 +458,6 @@ def plot_cdf(n_emp, n_mod, title=None, fileout=None):
         n_mod (np.ndarray): sample of model-simulated points
         title (string, optional): title
         fileout (string, optional): path to save the plot
-
-    Returns:
 
     """
     sup = max(n_emp.max(), n_mod.max())
@@ -518,8 +504,6 @@ def plot_id_pv(x, idd, pv, title, xlabel, fileout):
         xlabel (string, optional): label of x axis
         fileout (string, optional): path to save the plot
 
-    Returns:
-
     """
     fig, ax1 = plt.subplots()
 
@@ -542,7 +526,6 @@ def plot_id_pv(x, idd, pv, title, xlabel, fileout):
     ax2.set_yscale("log")
 
     ax2.scatter(x, pv, marker="^", color=c_right, s=75)
-    # ax2.plot(data[:,0],np.ones_like(data[:,-1])*0.05,'k--',alpha=0.5,label=r'$\alpha=0.05$')
 
     plt.legend()
     plt.tight_layout()

--- a/dev_scripts/whitelist.py
+++ b/dev_scripts/whitelist.py
@@ -1,4 +1,0 @@
-# flake8: noqa
-# noqa: C901
-# type: ignore
-# pylint: skip-file

--- a/project.toml
+++ b/project.toml
@@ -1,2 +1,0 @@
-[build-system]
-build-backend = 'setuptools.build_meta'

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,8 +21,7 @@ exclude =
     *.egg-info,
     .cache,
     .eggs,
-    black_it/__init__.py,
-    scripts/whitelist.py
+    black_it/__init__.py
 max-complexity = 10
 max-line-length = 120
 
@@ -33,9 +32,6 @@ force_grid_wrap=0
 use_parentheses=True
 line_length=88
 ensure_newline_before_comments=True
-
-[black]
-exclude = "dev_scripts/whitelist.py"
 
 [darglint]
 docstring_style=google

--- a/tox.ini
+++ b/tox.ini
@@ -76,7 +76,7 @@ deps =
     flake8-isort
     pydocstyle
 commands =
-    flake8 dadapy/base.py dadapy/metric_comparisons.py dadapy/clustering.py dadapy/id_estimation.py dadapy/density_estimation.py dadapy/data.py tests
+    flake8 dadapy/base.py dadapy/metric_comparisons.py dadapy/clustering.py dadapy/id_estimation.py dadapy/density_estimation.py dadapy/data.py tests dadapy/id_discrete.py dadapy/data_sets.py dadapy/kstar.py dadapy/density_advanced.py dadapy/__init__.py dadapy/plot.py
 
 [testenv:py3.8-nb]
 basepython = python3.8

--- a/tox.ini
+++ b/tox.ini
@@ -76,7 +76,25 @@ deps =
     flake8-isort
     pydocstyle
 commands =
-    flake8 dadapy/base.py dadapy/metric_comparisons.py dadapy/clustering.py dadapy/id_estimation.py dadapy/density_estimation.py dadapy/data.py tests dadapy/id_discrete.py dadapy/data_sets.py dadapy/kstar.py dadapy/density_advanced.py dadapy/__init__.py dadapy/plot.py dadapy/causal_graph.py dadapy/diff_imbalance.py dadapy/feature_weighting.py dadapy/hamming.py dadapy/neigh_graph.py
+    flake8 \
+        dadapy/__init__.py \
+        dadapy/base.py \
+        dadapy/causal_graph.py \
+        dadapy/clustering.py \
+        dadapy/data.py \
+        dadapy/data_sets.py \
+        dadapy/density_advanced.py \
+        dadapy/density_estimation.py \
+        dadapy/diff_imbalance.py \
+        dadapy/feature_weighting.py \
+        dadapy/hamming.py \
+        dadapy/id_discrete.py \
+        dadapy/id_estimation.py \
+        dadapy/kstar.py \
+        dadapy/metric_comparisons.py \
+        dadapy/neigh_graph.py \
+        dadapy/plot.py \
+        tests
 
 [testenv:py3.8-nb]
 basepython = python3.8

--- a/tox.ini
+++ b/tox.ini
@@ -76,7 +76,7 @@ deps =
     flake8-isort
     pydocstyle
 commands =
-    flake8 dadapy/base.py dadapy/metric_comparisons.py dadapy/clustering.py dadapy/id_estimation.py dadapy/density_estimation.py dadapy/data.py tests dadapy/id_discrete.py dadapy/data_sets.py dadapy/kstar.py dadapy/density_advanced.py dadapy/__init__.py dadapy/plot.py
+    flake8 dadapy/base.py dadapy/metric_comparisons.py dadapy/clustering.py dadapy/id_estimation.py dadapy/density_estimation.py dadapy/data.py tests dadapy/id_discrete.py dadapy/data_sets.py dadapy/kstar.py dadapy/density_advanced.py dadapy/__init__.py dadapy/plot.py dadapy/causal_graph.py dadapy/diff_imbalance.py dadapy/feature_weighting.py dadapy/hamming.py dadapy/neigh_graph.py
 
 [testenv:py3.8-nb]
 basepython = python3.8


### PR DESCRIPTION
This PR updates the linter configuration to process all main modules.

Previously, the following modules were excluded from linting:

* `data_sets.py`
* `id_discrete.py`
* `kstar.py`
* `plots.py`
* `density_advanced.py`
* `causal_graph.py`
* `diff_imbalance.py`
* `feature_weighting.py`
* `hamming.py`
* `neigh_graph.py`

With this change, the linter runs on the entire main codebase. 

I also removed three empty functions in metric comparisons, a useless `project.toml` file, and the `dev_scripts/whitelist.py`, which contained only dead (commented out) code. 

