### PR TITLE
Fix docstrigs, seed assignment, and additional bugfix

### DIFF
--- a/dadapy/_utils/density_estimation.py
+++ b/dadapy/_utils/density_estimation.py
@@ -27,7 +27,6 @@ def return_not_normalised_density_kstarNN(
     intrinsic_dim,
     kstar,
     interpolation=False,
-    bias=False,
 ):
     N = distances.shape[0]
     dc = np.zeros(N, dtype=float)
@@ -43,12 +42,6 @@ def return_not_normalised_density_kstarNN(
     else:
         log_den = np.log(kstar - 1, dtype=float)
         log_den_err = 1.0 / np.sqrt(kstar - 1, dtype=float)
-    if bias:
-        warnings.warn(
-            "bias contribution to the density error is an experimental feature \
-            and might change in the future"
-        )
-        log_den_err = (log_den_err**2 + (kstar / N) ** (2 / intrinsic_dim)) ** 0.5
 
     for i in range(N):
         dc[i] = distances[i, kstar[i]]
@@ -63,7 +56,7 @@ def return_not_normalised_density_kstarNN(
 
 
 def return_not_normalised_density_PAk(
-    distances, intrinsic_dim, kstar, interpolation=False, bias=False
+    distances, intrinsic_dim, kstar, interpolation=False
 ):
     N = distances.shape[0]
 
@@ -81,13 +74,6 @@ def return_not_normalised_density_PAk(
         log_den_err = np.sqrt(
             (4 * (kstar - 1) + 2) / ((kstar - 1) * ((kstar - 1) - 1)), dtype=float
         )
-
-    if bias:
-        warnings.warn(
-            "bias contribution to the density error is an experimental \
-            feature and might change in the future"
-        )
-        log_den_err = (log_den_err**2 + (kstar / N) ** (2 / intrinsic_dim)) ** 0.5
 
     dc = distances[np.arange(N), kstar]
 
@@ -149,7 +135,7 @@ def return_not_normalised_density_PAk(
 
 
 def return_not_normalised_density_PAk_optimized(
-    distances, intrinsic_dim, kstar, interpolation=False, bias=False
+    distances, intrinsic_dim, kstar, interpolation=False
 ):
     N = distances.shape[0]
     if not interpolation:
@@ -160,8 +146,6 @@ def return_not_normalised_density_PAk_optimized(
         log_den_err = np.sqrt(
             (4 * (kstar - 1) + 2) / ((kstar - 1) * ((kstar - 1) - 1)), dtype=float
         )
-    if bias:
-        log_den_err = (log_den_err**2 + (kstar / N) ** (2 / intrinsic_dim)) ** 0.5
 
     dc = distances[np.arange(N), kstar]
 

--- a/dadapy/_utils/id_estimation.py
+++ b/dadapy/_utils/id_estimation.py
@@ -16,8 +16,6 @@
 import matplotlib.pyplot as plt
 import numpy as np
 
-rng = np.random.default_rng()
-
 # from scipy.stats import epps_singleton_2samp as es2s
 from scipy.stats import ks_2samp
 
@@ -192,7 +190,7 @@ def correlation_integral(dists, scales, cond=False, plot=True):
 
 
 def _binomial_model_validation(
-    k, n, p, artificial_samples=100000, k_bootstrap=20, plot=False
+    k, n, p, rng, artificial_samples=100000, k_bootstrap=20, plot=False
 ):
     """Perform the model validation for the binomial estimator. To this aim, an artificial set of binomially distributed
     points is extracted and compared to the observed ones. The quantitative test should be performed by means of the 2-samples Epps-Singleton tests,
@@ -205,6 +203,7 @@ def _binomial_model_validation(
         k (int or np.ndarray(int)): Observed points in outer shells.
         n (np.ndarray(int)): Observed points in the inner shells.
         p (float): Tested Binomial parameter
+        rng (np.random.Generator): random number generator used to sample the artificial ensemble.
         artificial_samples (int, default=1000000): number of theoretical samples to be compared with the observed ones.
         k_bootstrap (int, default=1): number of bootstrap resampling in order to obtain more reliable p-values
         plot (bool, default=False): flag that, if se to True, allows to plot the observed vs theoretical distributions

--- a/dadapy/_utils/id_estimation.py
+++ b/dadapy/_utils/id_estimation.py
@@ -15,8 +15,6 @@
 
 import matplotlib.pyplot as plt
 import numpy as np
-
-# from scipy.stats import epps_singleton_2samp as es2s
 from scipy.stats import ks_2samp
 
 from ..plot import plot_cdf
@@ -57,11 +55,11 @@ def box_counting(
     sup = box_boundaries[1]
 
     # count the minimum amount of boxes touched
-    Ns = []
+    ns = []
     # loop over all scales
     for scale in input_scales:
         bin_temp = np.array(
-            [np.arange(inf, sup + 2 * scale, scale) for i in range(data.shape[1])]
+            [np.arange(inf, sup + 2 * scale, scale) for _ in range(data.shape[1])]
         )
         touched = []
         if n_offsets == 0:
@@ -76,43 +74,42 @@ def box_counting(
                     for x in bin_temp
                 ]
             )
-            H1, e = np.histogramdd(data, bins=bin_edges)
+            H1, _ = np.histogramdd(data, bins=bin_edges)
             touched.append(np.sum(H1 > 0))
-        Ns.append(touched)
-    Ns = np.array(Ns)
+        ns.append(touched)
+    ns = np.array(ns)
     if verb:
-        print(Ns)
+        print(ns)
     # From all sets N found, keep the smallest one at each scale
-    Ns = Ns.min(axis=1)
-    # Only keep scales at which Ns changed
-    scales = np.array([np.min(input_scales[Ns == x]) for x in np.unique(Ns)])
-    Ns = np.unique(Ns)
-    Ns = Ns[Ns > 0]
-    scales = scales[: len(Ns)]
+    ns = ns.min(axis=1)
+    # Only keep scales at which ns changed
+    scales = np.array([np.min(input_scales[ns == x]) for x in np.unique(ns)])
+    ns = np.unique(ns)
+    ns = ns[ns > 0]
+    scales = scales[: len(ns)]
     ind = np.argsort(scales)
     scales = scales[ind]
-    Ns = Ns[ind]
+    ns = ns[ind]
     if verb:
-        print("effective scales: ", scales, Ns)
+        print("effective scales: ", scales, ns)
     # perform fit with growing number of boxes
     cfs = []
     start = 1
     for i in range(start, len(scales)):
         coeffs = np.polyfit(
-            np.log(1 / scales[start - 1 : i + 1]), np.log(Ns[start - 1 : i + 1]), 1
+            np.log(1 / scales[start - 1 : i + 1]), np.log(ns[start - 1 : i + 1]), 1
         )
         cfs.append(coeffs[0])
 
-    # print(scales,cfs)
-    coeffs = np.polyfit(np.log(1 / scales), np.log(Ns), 1)
+    coeffs = np.polyfit(np.log(1 / scales), np.log(ns), 1)
     if verb:
-        print(np.log(Ns) / np.log(1 / scales[::-1]))
+        print(np.log(ns) / np.log(1 / scales[::-1]))
     # make plot
     if plot:
-        fig, ax = plt.subplots(figsize=(8, 6))
-        ax.scatter(np.log(1 / scales), np.log(Ns), c="teal", label="Measured ratios")
-        ax.set_ylabel("$\log N(\epsilon)$")
-        ax.set_xlabel("$\log 1/ \epsilon$")
+        _, ax = plt.subplots(figsize=(8, 6))
+        ax.scatter(np.log(1 / scales), np.log(ns), c="teal", label="Measured ratios")
+        ax.set_ylabel(r"$\log N(\epsilon)$")
+        ax.set_xlabel(r"$\log 1/ \epsilon$")
         fitted_y_vals = np.polyval(coeffs, np.log(1 / scales))
         ax.plot(
             np.log(1 / scales),
@@ -231,16 +228,14 @@ def _binomial_model_validation(
     if plot:
         plot_cdf(n - 1, n_samp)
 
-    # es_d, es_pv = es2s(n_samp, n - 1)
     ks_d, ks_pv = ks_2samp(n_samp, n - 1)
 
     # possibly test against re-sampled distribution using bootstrap
     if k_bootstrap > 1:
         kss = [ks_d]
         pvs = [ks_pv]
-        for ki in range(k_bootstrap):
+        for _ in range(k_bootstrap):
             n_temp = rng.choice(n, size=len(n), replace=True)
-            # es_d, es_pv = es2s(n_samp, n_temp - 1)
             ks_d, ks_pv = ks_2samp(n_samp, n_temp - 1)
             kss.append(ks_d)
             pvs.append(ks_pv)

--- a/dadapy/_utils/metric_comparisons.py
+++ b/dadapy/_utils/metric_comparisons.py
@@ -46,9 +46,7 @@ def _return_ranks(dist_indices_1, dist_indices_2, rng, k=1):
 
         for k_neighbor in range(k):
             if len(wr[k_neighbor]) == 0:
-                conditional_ranks[i, k_neighbor] = rng.integers(
-                    low=maxk_2, high=N, size=1
-                )
+                conditional_ranks[i, k_neighbor] = rng.integers(low=maxk_2, high=N)
             else:
                 conditional_ranks[i, k_neighbor] = wr[k_neighbor][0]
 

--- a/dadapy/_utils/utils.py
+++ b/dadapy/_utils/utils.py
@@ -98,8 +98,8 @@ def compute_cross_nn_distances(
         period (float, np.ndarray(float)): sizes of PBC walls. Single value is interpreted as cubic box.
 
     Returns:
-        distances (np.ndarray(int)): N x maxk matrix, indices of the neighbours of each point
-        dist_indices (np.ndarray(float)): N x maxk matrix, distances of the neighbours of each point
+        distances (np.ndarray(float)): N x maxk matrix, distances of the neighbours of each point
+        dist_indices (np.ndarray(int)): N x maxk matrix, indices of the neighbours of each point
 
     """
 
@@ -138,8 +138,8 @@ def compute_nn_distances(X, maxk, metric="euclidean", period=None, n_jobs=None):
         period (float, np.ndarray(float)): sizes of PBC walls. Single value is interpreted as cubic box.
 
     Returns:
-        distances (np.ndarray(int)): N x maxk matrix, indices of the neighbours of each point
-        dist_indices (np.ndarray(float)): N x maxk matrix, distances of the neighbours of each point
+        distances (np.ndarray(float)): N x maxk matrix, distances of the neighbours of each point
+        dist_indices (np.ndarray(int)): N x maxk matrix, indices of the neighbours of each point
 
     """
 

--- a/dadapy/clustering.py
+++ b/dadapy/clustering.py
@@ -62,6 +62,7 @@ class Clustering(DensityEstimation):
         period=None,
         verbose=False,
         n_jobs=cores,
+        rng_seed=42,
     ):
         """Initialise the Clustering class."""
         super().__init__(
@@ -71,6 +72,7 @@ class Clustering(DensityEstimation):
             period=period,
             verbose=verbose,
             n_jobs=n_jobs,
+            rng_seed=rng_seed,
         )
 
         self.cluster_indices = None

--- a/dadapy/clustering.py
+++ b/dadapy/clustering.py
@@ -49,7 +49,7 @@ class Clustering(DensityEstimation):
             the estimated log density of the saddle point between each couple of peaks.
         log_den_bord_err (np.ndarray(float)): A matrix of dimensions N_clusters x N_clusters containing
             the estimated error on the log density of the saddle point between each couple of peaks.
-        bord_indices (np.ndarray(float)): A matrix of dimensions N_clusters x N_clusters containing the indices of
+        bord_indices (np.ndarray(int)): A matrix of dimensions N_clusters x N_clusters containing the indices of
             the saddle point between each couple of peaks.
 
     """

--- a/dadapy/data.py
+++ b/dadapy/data.py
@@ -143,7 +143,7 @@ class Data(Clustering, DensityAdvanced, MetricComparisons, FeatureWeighting):
             log_lik = -ut._neg_loglik(self.dtype, gride_id, mus, n1s, n2s)
             self.compute_kstar(alpha, bonferroni_deloc, bonferroni_loc)
 
-            ids.append(id)
+            ids.append(gride_id)
             ids_err.append(id_err)
             kstars.append(self.kstar)
             log_likelihoods.append(log_lik)

--- a/dadapy/data.py
+++ b/dadapy/data.py
@@ -31,8 +31,6 @@ from dadapy.density_advanced import DensityAdvanced
 from dadapy.feature_weighting import FeatureWeighting
 from dadapy.metric_comparisons import MetricComparisons
 
-rng = np.random.default_rng()
-
 cores = multiprocessing.cpu_count()
 np.set_printoptions(precision=2)
 os.getcwd()
@@ -50,6 +48,7 @@ class Data(Clustering, DensityAdvanced, MetricComparisons, FeatureWeighting):
         verbose=False,
         n_jobs=cores,
         working_memory=1024,
+        rng_seed=42,
     ):
         """Initialise a Data object, container of all DADApy methods.
 
@@ -63,6 +62,8 @@ class Data(Clustering, DensityAdvanced, MetricComparisons, FeatureWeighting):
             verbose (bool): whether you want the code to speak or shut up
             n_jobs (int): number of cores to be used
             working_memory (int): working memory (TODO: currently unused)
+            rng_seed (int): seed used to build ``self.rng``. Setting this makes every randomised
+                method called on the instance reproducible.
         """
         super().__init__(
             coordinates=coordinates,
@@ -71,6 +72,7 @@ class Data(Clustering, DensityAdvanced, MetricComparisons, FeatureWeighting):
             period=period,
             verbose=verbose,
             n_jobs=n_jobs,
+            rng_seed=rng_seed,
         )
 
     def return_ids_kstar_gride(
@@ -134,9 +136,11 @@ class Data(Clustering, DensityAdvanced, MetricComparisons, FeatureWeighting):
                 ]
             )
             # compute the id using Gride
-            id, id_err = self._compute_id_gride_single_scale(d0, d1, mus, n1s, n2s, eps)
-            self.set_id(id)
-            log_lik = -ut._neg_loglik(self.dtype, id, mus, n1s, n2s)
+            gride_id, id_err = self._compute_id_gride_single_scale(
+                d0, d1, mus, n1s, n2s, eps
+            )
+            self.set_id(gride_id)
+            log_lik = -ut._neg_loglik(self.dtype, gride_id, mus, n1s, n2s)
             self.compute_kstar(alpha, bonferroni_deloc, bonferroni_loc)
 
             ids.append(id)
@@ -155,7 +159,7 @@ class Data(Clustering, DensityAdvanced, MetricComparisons, FeatureWeighting):
             id_scale += self.distances[i, n2]
         id_scale /= 2 * self.N
 
-        self.intrinsic_dim = id
+        self.intrinsic_dim = gride_id
         self.intrinsic_dim_err = id_err
         self.intrinsic_dim_scale = id_scale
 
@@ -214,7 +218,7 @@ class Data(Clustering, DensityAdvanced, MetricComparisons, FeatureWeighting):
             # set new ratio
             r_eff = min(0.975, 0.2032 ** (1.0 / self.intrinsic_dim)) if r is None else r
             # compute id using the k*
-            ide, id_err, scale, pv = self.compute_id_binomial_k(
+            ide, id_err, _, pv = self.compute_id_binomial_k(
                 self.kstar, r_eff, bayes=False, plot_mv=plot_mv, k_bootstrap=k_bootstrap
             )
             # compute likelihood

--- a/dadapy/data_sets.py
+++ b/dadapy/data_sets.py
@@ -34,9 +34,6 @@ np.set_printoptions(precision=2)
 os.getcwd()
 
 
-rng = np.random.default_rng(42)
-
-
 class DataSets:
     """DataSets class."""
 
@@ -51,7 +48,7 @@ class DataSets:
 
     @staticmethod
     def return_inf_imb_jackknife_d1_to_d2(
-        d1: Data, d2: Data, file_name="jackknife.txt", n=None, k=1
+        d1: Data, d2: Data, file_name="jackknife.txt", n=None, k=1, rng=None
     ):
         """Return the mean and the standard deviation of the information imbalalce using the Jackknife method.
 
@@ -62,6 +59,8 @@ class DataSets:
                 "jackknife.txt". Set to "None" to avoid saving.
             n (_type_, optional): Number of Jackknife repetitions. Defaults to the number of dataset points.
             k (int, optional): The number of neighbours for the imbalance computations. Defaults to 1.
+            rng (np.random.Generator, optional): random number generator used for the jackknife
+                resampling. Defaults to ``d1.rng``.
 
         Returns:
             mean and standard deviation of the imbalance estimates from d1 to d2.
@@ -69,6 +68,8 @@ class DataSets:
         assert len(d1.X) == len(d2.X)
         if n is None:
             n = len(d1.X)
+        if rng is None:
+            rng = d1.rng
 
         if file_name is not None:
             print("Saving imbalances in " + file_name)

--- a/dadapy/density_advanced.py
+++ b/dadapy/density_advanced.py
@@ -434,7 +434,6 @@ class DensityAdvanced(DensityEstimation, NeighGraph):
                 self.intrinsic_dim,
                 self.kstar,
                 interpolation=False,
-                bias=False,
             )
             # Normalise density
             log_den -= np.log(self.N)

--- a/dadapy/density_advanced.py
+++ b/dadapy/density_advanced.py
@@ -74,6 +74,7 @@ class DensityAdvanced(DensityEstimation, NeighGraph):
         period=None,
         verbose=False,
         n_jobs=cores,
+        rng_seed=42,
     ):
         """Initialise the DensityEstimation class."""
         super().__init__(
@@ -83,6 +84,7 @@ class DensityAdvanced(DensityEstimation, NeighGraph):
             period=period,
             verbose=verbose,
             n_jobs=n_jobs,
+            rng_seed=rng_seed,
         )
 
         self.grads = None
@@ -476,8 +478,6 @@ class DensityAdvanced(DensityEstimation, NeighGraph):
 
             if self.verb:
                 print("{0:0.2f} seconds inverting A matrix".format(time.time() - sec2))
-
-            sec2 = time.time()
 
         sec2 = time.time()
         if self.verb:

--- a/dadapy/density_estimation.py
+++ b/dadapy/density_estimation.py
@@ -92,7 +92,7 @@ class DensityEstimation(KStar):
 
     # ----------------------------------------------------------------------------------------------
 
-    def compute_density_kNN(self, k=10, bias=False):
+    def compute_density_kNN(self, k=10):
         """Compute the density of each point using a simple kNN estimator.
 
         Args:
@@ -115,7 +115,6 @@ class DensityEstimation(KStar):
             self.intrinsic_dim,
             self.kstar,
             interpolation=False,
-            bias=bias,
         )
 
         # Normalise density
@@ -133,7 +132,7 @@ class DensityEstimation(KStar):
     # ----------------------------------------------------------------------------------------------
 
     def compute_density_kstarNN(
-        self, alpha=1e-6, bias=False, bonferroni_deloc=False, bonferroni_loc=False
+        self, alpha=1e-6, bonferroni_deloc=False, bonferroni_loc=False
     ):
         """Compute the density of each point using a simple kNN estimator with an optimal choice of k.
 
@@ -162,7 +161,6 @@ class DensityEstimation(KStar):
             self.intrinsic_dim,
             self.kstar,
             interpolation=False,
-            bias=bias,
         )
 
         # Normalise density
@@ -448,7 +446,7 @@ class DensityEstimation(KStar):
         )
 
         log_den, log_den_err, _ = return_not_normalised_density_PAk(
-            cross_distances, self.intrinsic_dim, kstar, self.maxk, interpolation=True
+            cross_distances, self.intrinsic_dim, kstar, interpolation=True
         )
 
         # Normalise density

--- a/dadapy/density_estimation.py
+++ b/dadapy/density_estimation.py
@@ -57,6 +57,7 @@ class DensityEstimation(KStar):
         period=None,
         verbose=False,
         n_jobs=cores,
+        rng_seed=42,
     ):
         """Initialise the DensityEstimation class."""
         super().__init__(
@@ -66,6 +67,7 @@ class DensityEstimation(KStar):
             period=period,
             verbose=verbose,
             n_jobs=n_jobs,
+            rng_seed=rng_seed,
         )
 
         self.log_den = None

--- a/dadapy/diff_imbalance.py
+++ b/dadapy/diff_imbalance.py
@@ -195,7 +195,7 @@ class DiffImbalance:
                     "Argument distances_B is not None; data_B will be ignored.",
                     stacklevel=2,
                 )
-            # self.distances_B = jnp.array(distances_B)  # noqa: E800
+
             assert (
                 distances_B.shape[0] == distances_B.shape[1]
             ), f"Argument distances_B should be a square matrix, while it has shape {distances_B.shape}"

--- a/dadapy/feature_weighting.py
+++ b/dadapy/feature_weighting.py
@@ -76,6 +76,7 @@ class FeatureWeighting(Base):
         period=None,
         verbose=False,
         n_jobs=cores,
+        rng_seed=42,
     ):
         """Initialise the FeatureWeighting object."""
         super().__init__(
@@ -85,6 +86,7 @@ class FeatureWeighting(Base):
             period=period,
             verbose=verbose,
             n_jobs=n_jobs,
+            rng_seed=rng_seed,
         )
 
         # This is quite useful for debugging

--- a/dadapy/id_discrete.py
+++ b/dadapy/id_discrete.py
@@ -255,7 +255,7 @@ class IdDiscrete(Base):
                         + " points, the counting of k could be wrong, "
                         + "as more points might be present within the selected Rk. In order not to affect "
                         + "the statistics a mask is provided to remove them from the calculation of the "
-                        + "likelihood or posterior.\nConsiself.kder recomputing NN with higher maxk or lowering Rk."
+                        + "likelihood or posterior.\nConsider recomputing NN with higher maxk or lowering Rk."
                     )
         if self.verb:
             print("n and k computed")

--- a/dadapy/id_discrete.py
+++ b/dadapy/id_discrete.py
@@ -31,7 +31,6 @@ from dadapy import plot as ddp
 from dadapy.base import Base
 
 cores = multiprocessing.cpu_count()
-rng = np.random.default_rng()
 
 
 class IdDiscrete(Base):
@@ -63,6 +62,7 @@ class IdDiscrete(Base):
         weights=None,
         verbose=False,
         n_jobs=cores,
+        rng_seed=42,
     ):
         """Instantiate the IdDiscrete object.
 
@@ -78,6 +78,7 @@ class IdDiscrete(Base):
             weights (np.ndarray(int), default=None): keeps into account explicitly possible repetitions of datapoints
             verbose (bool): whether you want the code to speak or shut up
             n_jobs (int): number of cores to be used
+            rng_seed (int): seed used to build ``self.rng``.
 
         """
         super().__init__(
@@ -86,6 +87,7 @@ class IdDiscrete(Base):
             maxk=maxk,
             verbose=verbose,
             n_jobs=n_jobs,
+            rng_seed=rng_seed,
         )
 
         self.central_point = 0 if is_network else 1
@@ -1067,15 +1069,18 @@ class IdDiscrete(Base):
             replicas = int(artificial_samples / self.n.shape[0])
             if isinstance(self.ln, np.ndarray):
                 n_model = np.array(
-                    [rng.binomial(ki, pi, size=replicas) for ki, pi in zip(k_eff, p)]
+                    [
+                        self.rng.binomial(ki, pi, size=replicas)
+                        for ki, pi in zip(k_eff, p)
+                    ]
                 ).reshape(-1)
             else:
                 n_model = np.array(
-                    [rng.binomial(ki, p, size=replicas) for ki in k_eff]
+                    [self.rng.binomial(ki, p, size=replicas) for ki in k_eff]
                 ).reshape(-1)
 
         else:
-            n_model = rng.binomial(k_eff, p)
+            n_model = self.rng.binomial(k_eff, p)
 
         if self.central_point == 0:
             n_model = n_model[n_model > 0]
@@ -1225,6 +1230,7 @@ class IdDiscrete(Base):
 
 
 if __name__ == "__main__":
+    rng = np.random.default_rng(0)
     X = rng.integers(0, 20, size=(1000, 2))
     ide = IdDiscrete(coordinates=X)
     ide.compute_distances(maxk=30, metric="manhattan", period=20)

--- a/dadapy/id_estimation.py
+++ b/dadapy/id_estimation.py
@@ -881,7 +881,12 @@ class IdEstimation(Base):
             return 0
 
         _, pv = bmv(
-            k, n, r**self.intrinsic_dim, self.rng, plot=plot_mv, k_bootstrap=k_bootstrap
+            k,
+            n,
+            r**self.intrinsic_dim,
+            self.rng,
+            plot=plot_mv,
+            k_bootstrap=k_bootstrap,
         )
 
         return self.intrinsic_dim, self.intrinsic_dim_err, self.intrinsic_dim_scale, pv

--- a/dadapy/id_estimation.py
+++ b/dadapy/id_estimation.py
@@ -18,6 +18,7 @@ The *id_estimation* module contains the *IdEstimation* class.
 
 The different algorithms of intrinsic dimension estimation are implemented as methods of this class.
 """
+
 import copy
 import math
 import multiprocessing
@@ -769,7 +770,7 @@ class IdEstimation(Base):
             print("Select a proper method for id computation")
             return 0
 
-        ks, pv = bmv(k_eff, n_eff, r**self.intrinsic_dim, plot=plot_mv)
+        _, pv = bmv(k_eff, n_eff, r**self.intrinsic_dim, self.rng, plot=plot_mv)
 
         return self.intrinsic_dim, self.intrinsic_dim_err, self.intrinsic_dim_scale, pv
 
@@ -879,8 +880,8 @@ class IdEstimation(Base):
             print("select a proper method for id computation")
             return 0
 
-        ks, pv = bmv(
-            k, n, r**self.intrinsic_dim, plot=plot_mv, k_bootstrap=k_bootstrap
+        _, pv = bmv(
+            k, n, r**self.intrinsic_dim, self.rng, plot=plot_mv, k_bootstrap=k_bootstrap
         )
 
         return self.intrinsic_dim, self.intrinsic_dim_err, self.intrinsic_dim_scale, pv

--- a/dadapy/kstar.py
+++ b/dadapy/kstar.py
@@ -50,6 +50,7 @@ class KStar(IdEstimation):
         period=None,
         verbose=False,
         n_jobs=cores,
+        rng_seed=42,
     ):
         """Initialise the KStar class."""
         super().__init__(
@@ -59,6 +60,7 @@ class KStar(IdEstimation):
             period=period,
             verbose=verbose,
             n_jobs=n_jobs,
+            rng_seed=rng_seed,
         )
 
         self.kstar = None

--- a/dadapy/metric_comparisons.py
+++ b/dadapy/metric_comparisons.py
@@ -50,6 +50,7 @@ class MetricComparisons(Base):
         period=None,
         verbose=False,
         n_jobs=cores,
+        rng_seed=42,
     ):
         """Class containing several methods to compare metric spaces obtained using subsets of the data features.
 
@@ -63,6 +64,7 @@ class MetricComparisons(Base):
             period (np.array(float), optional): array containing the periodicity of each coordinate. Default is None
             verbose (bool): whether you want the code to speak or shut up
             n_jobs (int): number of cores to be used
+            rng_seed (int): seed used to build ``self.rng``.
         """
         super().__init__(
             coordinates=coordinates,
@@ -71,6 +73,7 @@ class MetricComparisons(Base):
             period=period,
             verbose=verbose,
             n_jobs=n_jobs,
+            rng_seed=rng_seed,
         )
 
     def return_information_imbalace(

--- a/dadapy/neigh_graph.py
+++ b/dadapy/neigh_graph.py
@@ -76,6 +76,7 @@ class NeighGraph(KStar):
         period=None,
         verbose=False,
         n_jobs=cores,
+        rng_seed=42,
     ):
         """Initialise the DensityEstimation class."""
         super().__init__(
@@ -85,6 +86,7 @@ class NeighGraph(KStar):
             period=period,
             verbose=verbose,
             n_jobs=n_jobs,
+            rng_seed=rng_seed,
         )
 
         self.nspar = None

--- a/dadapy/plot.py
+++ b/dadapy/plot.py
@@ -232,7 +232,7 @@ def get_dendrogram(Data, cmap="viridis", savefig="", logscale=True):  # noqa: C9
     # Obtain the dendrogram in form of links
     nlinks = 0
     clnew = Data.N_clusters
-    for j in range(Data.N_clusters - 1):
+    for _ in range(Data.N_clusters - 1):
         aa = np.argmin(d12)
         nlinks = nlinks + 1
         L.append(clnew + nlinks)

--- a/dadapy/plot.py
+++ b/dadapy/plot.py
@@ -42,9 +42,7 @@ def plot_ID_line_fit_estimation(Data, decimation=0.9, fraction_used=0.9):
 
     x_, y_ = np.atleast_2d(x[:Nele_eff]).T, y[:Nele_eff]
 
-    slope, residuals, _, _ = np.linalg.lstsq(
-        x_, y_, rcond=None
-    )  # x[:Nele_eff, None]?
+    slope, residuals, _, _ = np.linalg.lstsq(x_, y_, rcond=None)  # x[:Nele_eff, None]?
 
     plt.plot(x, y, "o")
     plt.plot(x[:Nele_eff], y[:Nele_eff], "o")

--- a/dadapy/plot.py
+++ b/dadapy/plot.py
@@ -42,7 +42,7 @@ def plot_ID_line_fit_estimation(Data, decimation=0.9, fraction_used=0.9):
 
     x_, y_ = np.atleast_2d(x[:Nele_eff]).T, y[:Nele_eff]
 
-    slope, residuals, rank, s = np.linalg.lstsq(
+    slope, residuals, _, _ = np.linalg.lstsq(
         x_, y_, rcond=None
     )  # x[:Nele_eff, None]?
 
@@ -87,7 +87,7 @@ def plot_SLAn(Data, linkage="single"):
     else:
         print("ERROR: select a valid linkage criterion")
 
-    fig, ax = plt.subplots(nrows=1, ncols=1)  # create figure & 1 axis
+    plt.subplots(nrows=1, ncols=1)  # create figure & 1 axis
     sp.cluster.hierarchy.dendrogram(DD)
     plt.show()
 
@@ -104,7 +104,7 @@ def plot_MDS(Data, cmap="viridis", savefig=""):
     for i in range(Data.N_clusters):
         d_dis[i][i] = 0.0
     out = model.fit_transform(d_dis)
-    fig, ax = plt.subplots(nrows=1, ncols=1)
+    _, ax = plt.subplots(nrows=1, ncols=1)
     s = []
     col = []
     for i in range(Data.N_clusters):
@@ -141,7 +141,6 @@ def plot_MDS(Data, cmap="viridis", savefig=""):
     rr = np.amax(Rho_bord_m)
     if rr > 0.0:
         Rho_bord_m = Rho_bord_m / rr * 100.0
-    start_idx, end_idx = np.where(out)
     segments = [
         [out[i, :], out[j, :]] for i in range(len(out)) for j in range(len(out))
     ]
@@ -164,7 +163,7 @@ def plot_matrix(Data, savefig=""):
     for j in range(Data.N_clusters):
         topography[j, j] = Data.log_den[Data.cluster_centers[j]]
 
-    fig, ax = plt.subplots(nrows=1, ncols=1)
+    plt.subplots(nrows=1, ncols=1)
     plt.imshow(topography, cmap="gray_r", interpolation=None)
     plt.xticks(np.arange(0, Data.N_clusters, step=1))
     plt.yticks(np.arange(0, Data.N_clusters, step=1))
@@ -261,16 +260,16 @@ def get_dendrogram(Data, cmap="viridis", savefig="", logscale=True):  # noqa: C9
         e1new = []
         e2new = []
         d12new = []
-        for j in unt:
+        for u in unt:
             t = 0
             dmin = 9.9e99
             for _ in d12:
-                if (e1[t] == j) | (e2[t] == j):
+                if (e1[t] == u) | (e2[t] == u):
                     if (e1[t] == fe) | (e2[t] == fe) | (e1[t] == fs) | (e2[t] == fs):
                         if d12[t] < dmin:
                             dmin = d12[t]
                 t = t + 1
-            e1new.append(j)
+            e1new.append(u)
             e2new.append(newname)
             d12new.append(dmin)
 
@@ -505,7 +504,7 @@ def plot_id_pv(x, idd, pv, title, xlabel, fileout):
         fileout (string, optional): path to save the plot
 
     """
-    fig, ax1 = plt.subplots()
+    _, ax1 = plt.subplots()
 
     c_left = "firebrick"
     c_right = "navy"

--- a/dadapy/plot.py
+++ b/dadapy/plot.py
@@ -28,7 +28,7 @@ def plot_ID_line_fit_estimation(Data, decimation=0.9, fraction_used=0.9):
     mus = Data.distances[:, 2] / Data.distances[:, 1]
 
     idx = np.arange(mus.shape[0])
-    idx = np.random.choice(
+    idx = Data.rng.choice(
         idx, size=(int(np.around(Data.N * decimation))), replace=False
     )
     mus = mus[idx]
@@ -542,8 +542,9 @@ if __name__ == "__main__":
     # basic tests for plotting functions
     from dadapy import Data
 
+    rng = np.random.default_rng(0)
     X = np.vstack(
-        (np.random.normal(0, 1, size=(1000, 5)), np.random.normal(5, 1, size=(1000, 5)))
+        (rng.normal(0, 1, size=(1000, 5)), rng.normal(5, 1, size=(1000, 5)))
     )
 
     data = Data(X)

--- a/dadapy/plot.py
+++ b/dadapy/plot.py
@@ -543,9 +543,7 @@ if __name__ == "__main__":
     from dadapy import Data
 
     rng = np.random.default_rng(0)
-    X = np.vstack(
-        (rng.normal(0, 1, size=(1000, 5)), rng.normal(5, 1, size=(1000, 5)))
-    )
+    X = np.vstack((rng.normal(0, 1, size=(1000, 5)), rng.normal(5, 1, size=(1000, 5))))
 
     data = Data(X)
 

--- a/setup.py
+++ b/setup.py
@@ -14,121 +14,43 @@ class get_numpy_include(object):
         return numpy.get_include()
 
 
-ext_modules = []
+NUMPY_MACROS = [
+    ("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION"),
+    ("NPY_TARGET_VERSION", "NPY_1_22_API_VERSION"),
+]
 
-ext_modules += [
-    Extension(
-        "dadapy._cython.cython_clustering",
-        sources=["dadapy/_cython/cython_clustering.c"],
+
+def cython_extension(name):
+    return Extension(
+        f"dadapy._cython.{name}",
+        sources=[f"dadapy/_cython/{name}.c"],
         include_dirs=[get_numpy_include()],
-        define_macros=[
-            ("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION"),
-            ("NPY_TARGET_VERSION", "NPY_1_22_API_VERSION"),
-        ],
+        define_macros=NUMPY_MACROS,
     )
+
+
+serial_modules = [
+    "cython_clustering",
+    "cython_clustering_v2",
+    "cython_maximum_likelihood_opt",
+    "cython_maximum_likelihood_opt_full",
+    "cython_density",
+    "cython_overlap",
+    "cython_grads",
 ]
 
-ext_modules += [
-    Extension(
-        "dadapy._cython.cython_clustering_v2",
-        sources=["dadapy/_cython/cython_clustering_v2.c"],
-        include_dirs=[get_numpy_include()],
-        define_macros=[
-            ("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION"),
-            ("NPY_TARGET_VERSION", "NPY_1_22_API_VERSION"),
-        ],
-    )
+parallel_modules = [
+    "cython_distances",
+    "cython_differentiable_imbalance",
 ]
 
-ext_modules += [
-    Extension(
-        "dadapy._cython.cython_maximum_likelihood_opt",
-        sources=["dadapy/_cython/cython_maximum_likelihood_opt.c"],
-        include_dirs=[get_numpy_include()],
-        define_macros=[
-            ("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION"),
-            ("NPY_TARGET_VERSION", "NPY_1_22_API_VERSION"),
-        ],
-    )
-]
-
-ext_modules += [
-    Extension(
-        "dadapy._cython.cython_maximum_likelihood_opt_full",
-        sources=["dadapy/_cython/cython_maximum_likelihood_opt_full.c"],
-        include_dirs=[get_numpy_include()],
-        define_macros=[
-            ("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION"),
-            ("NPY_TARGET_VERSION", "NPY_1_22_API_VERSION"),
-        ],
-    )
-]
-
-
-ext_modules += [
-    Extension(
-        "dadapy._cython.cython_density",
-        sources=["dadapy/_cython/cython_density.c"],
-        include_dirs=[get_numpy_include()],
-        define_macros=[
-            ("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION"),
-            ("NPY_TARGET_VERSION", "NPY_1_22_API_VERSION"),
-        ],
-    )
-]
-
-ext_modules += [
-    Extension(
-        "dadapy._cython.cython_overlap",
-        sources=["dadapy/_cython/cython_overlap.c"],
-        include_dirs=[get_numpy_include()],
-        define_macros=[
-            ("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION"),
-            ("NPY_TARGET_VERSION", "NPY_1_22_API_VERSION"),
-        ],
-    )
-]
-
-ext_modules += [
-    Extension(
-        "dadapy._cython.cython_grads",
-        sources=["dadapy/_cython/cython_grads.c"],
-        include_dirs=[get_numpy_include()],
-        define_macros=[
-            ("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION"),
-            ("NPY_TARGET_VERSION", "NPY_1_22_API_VERSION"),
-        ],
-    )
-]
-
-exts_parallel = [
-    Extension(
-        "dadapy._cython.cython_distances",
-        sources=["dadapy/_cython/cython_distances.c"],
-        include_dirs=[get_numpy_include()],
-        define_macros=[
-            ("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION"),
-            ("NPY_TARGET_VERSION", "NPY_1_22_API_VERSION"),
-        ],
-    ),
-    Extension(
-        "dadapy._cython.cython_differentiable_imbalance",
-        sources=["dadapy/_cython/cython_differentiable_imbalance.c"],
-        include_dirs=[get_numpy_include()],
-        define_macros=[
-            ("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION"),
-            ("NPY_TARGET_VERSION", "NPY_1_22_API_VERSION"),
-        ],
-    ),
-]
-
-extra_compile_args = (["-fopenmp"],)
-extra_link_args = (["-fopenmp"],)
+ext_modules = [cython_extension(name) for name in serial_modules]
+exts_parallel = [cython_extension(name) for name in parallel_modules]
 
 # Check if the '-fopenmp' flag is supported
-command = 'gcc -fopenmp -E - < /dev/null > /dev/null 2>&1 && echo "OpenMP supported" || echo "OpenMP not supported"'
+openmp_supported = os.system("gcc -fopenmp -E - < /dev/null > /dev/null 2>&1") == 0
 
-if os.system(command) == "OpenMP supported":
+if openmp_supported:
     # If '-fopenmp' is supported, add the extra compile and link arguments
     # Installing cython_distances using OpenMP
     for ext_parallel in exts_parallel:


### PR DESCRIPTION
Fixes #148. 

In addition to fixing the typos in the docstrings as requested by issue #148, I:
- made consistent the RNG calls across the codebase. Now every module initializes the base class's self.rng with a consistent seed, rather than using an ad hoc policy, sometimes not even specifying the seed. 
- cleanup and fix bugs in the setup.py file
- removed the bias parameter in density estimation. This was an experimental feature I added 4 years ago without validation. It was set to False by default and never used elsewhere in the package. 
