### PR TITLE
Fix issue #145: set max OPENBLAS_NUM_THREADS to 128

### DIFF
--- a/dadapy/_utils/utils.py
+++ b/dadapy/_utils/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 import multiprocessing
+import os
 import warnings
 
 import numpy as np
@@ -23,7 +24,11 @@ from scipy.stats import beta as beta_d
 from sklearn.metrics import pairwise_distances
 from sklearn.neighbors import NearestNeighbors
 
-cores = multiprocessing.cpu_count()
+# Cap default thread count to avoid OpenBLAS's 128-thread build limit on
+# many-core machines. Users can override per-call via the n_jobs argument
+# or globally via the OPENBLAS_NUM_THREADS environment variable.
+_openblas_limit = int(os.environ.get("OPENBLAS_NUM_THREADS", 128))
+cores = min(multiprocessing.cpu_count(), _openblas_limit)
 
 
 def compute_all_distances(X, n_jobs=cores, metric="euclidean"):

--- a/dadapy/_utils/utils.py
+++ b/dadapy/_utils/utils.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 import multiprocessing
-import os
 import warnings
 
 import numpy as np
@@ -25,10 +24,8 @@ from sklearn.metrics import pairwise_distances
 from sklearn.neighbors import NearestNeighbors
 
 # Cap default thread count to avoid OpenBLAS's 128-thread build limit on
-# many-core machines. Users can override per-call via the n_jobs argument
-# or globally via the OPENBLAS_NUM_THREADS environment variable.
-_openblas_limit = int(os.environ.get("OPENBLAS_NUM_THREADS", 128))
-cores = min(multiprocessing.cpu_count(), _openblas_limit)
+# many-core machines. Users can override per-call via the n_jobs argument.
+cores = min(multiprocessing.cpu_count(), 128)
 
 
 def compute_all_distances(X, n_jobs=cores, metric="euclidean"):

--- a/dadapy/base.py
+++ b/dadapy/base.py
@@ -56,13 +56,13 @@ class Base:
             njobs (int): number of cores to be used
         """
         self.X = coordinates
-        self.maxk = maxk  # remove from here
+        self.maxk = maxk
         self.verb = verbose
         self.n_jobs = n_jobs
         self.dims = None
         self.N = None
-        self.metric = "euclidean"  # remove from here
-        self.period = period  # remove from here
+        self.metric = "euclidean"
+        self.period = period
         self.rng = np.random.default_rng(rng_seed)
 
         if self.X is not None:
@@ -85,7 +85,7 @@ class Base:
             self.dims = coordinates.shape[1]
             self.distances = None
             self.dist_indices = None
-            if self.maxk is None:  # remove from here
+            if self.maxk is None:
                 self.maxk = min(100, self.N - 1)
 
         if distances is not None:

--- a/dadapy/base.py
+++ b/dadapy/base.py
@@ -18,15 +18,17 @@ The *base* module contains the *Base* class.
 
 This class contains essential methods and attributes needed for all other classes.
 """
-import multiprocessing
+
 import time
 import warnings
 
 import numpy as np
 
-from dadapy._utils.utils import compute_nn_distances, from_all_distances_to_nndistances
-
-cores = multiprocessing.cpu_count()
+from dadapy._utils.utils import (
+    compute_nn_distances,
+    cores,
+    from_all_distances_to_nndistances,
+)
 
 
 class Base:

--- a/dadapy/clustering.py
+++ b/dadapy/clustering.py
@@ -19,7 +19,6 @@ The *clustering* module contains the *Clustering* class.
 Density-based clustering algorithms are implemented as methods of this class.
 """
 
-import multiprocessing
 import time
 import warnings
 
@@ -28,9 +27,8 @@ import scipy as sp
 
 from dadapy._cython import cython_clustering as cf
 from dadapy._cython import cython_clustering_v2 as cf2
+from dadapy._utils.utils import cores
 from dadapy.density_estimation import DensityEstimation
-
-cores = multiprocessing.cpu_count()
 
 
 class Clustering(DensityEstimation):

--- a/dadapy/data.py
+++ b/dadapy/data.py
@@ -20,18 +20,17 @@ Such a class inherits from all other classes defined in the package and as such 
 all the algorithms implemented in Dadapy.
 """
 
-import multiprocessing
 import os
 
 import numpy as np
 
 from dadapy._utils import utils as ut
+from dadapy._utils.utils import cores
 from dadapy.clustering import Clustering
 from dadapy.density_advanced import DensityAdvanced
 from dadapy.feature_weighting import FeatureWeighting
 from dadapy.metric_comparisons import MetricComparisons
 
-cores = multiprocessing.cpu_count()
 np.set_printoptions(precision=2)
 os.getcwd()
 

--- a/dadapy/data_sets.py
+++ b/dadapy/data_sets.py
@@ -20,16 +20,14 @@ Such a class is useful to manipulate multiple different datasets at the same tim
 between datasets, such as the information imbalance.
 """
 
-import multiprocessing
 import os
 
 import numpy as np
 
 from dadapy._utils.metric_comparisons import _return_imbalance
-from dadapy._utils.utils import compute_nn_distances
+from dadapy._utils.utils import compute_nn_distances, cores
 from dadapy.data import Data
 
-cores = multiprocessing.cpu_count()
 np.set_printoptions(precision=2)
 os.getcwd()
 

--- a/dadapy/data_sets.py
+++ b/dadapy/data_sets.py
@@ -25,7 +25,7 @@ import os
 import numpy as np
 
 from dadapy._utils.metric_comparisons import _return_imbalance
-from dadapy._utils.utils import compute_nn_distances, cores
+from dadapy._utils.utils import compute_nn_distances
 from dadapy.data import Data
 
 np.set_printoptions(precision=2)

--- a/dadapy/density_advanced.py
+++ b/dadapy/density_advanced.py
@@ -22,7 +22,6 @@ the methods in the DensityAdvanced class are based on the sparse neighbourhood g
 in the NeighGraph class.
 """
 
-import multiprocessing
 import time
 import warnings
 
@@ -32,10 +31,9 @@ from scipy import sparse
 
 from dadapy._cython import cython_grads as cgr
 from dadapy._utils.density_estimation import return_not_normalised_density_kstarNN
+from dadapy._utils.utils import cores
 from dadapy.density_estimation import DensityEstimation
 from dadapy.neigh_graph import NeighGraph
-
-cores = multiprocessing.cpu_count()
 
 
 class DensityAdvanced(DensityEstimation, NeighGraph):

--- a/dadapy/density_estimation.py
+++ b/dadapy/density_estimation.py
@@ -19,7 +19,6 @@ The *density_estimation* module contains the *DensityEstimation* class.
 The different algorithms of density estimation are implemented as methods of this class.
 """
 
-import multiprocessing
 import time
 import warnings
 
@@ -31,10 +30,8 @@ from dadapy._utils.density_estimation import (
     return_not_normalised_density_PAk,
     return_not_normalised_density_PAk_optimized,
 )
-from dadapy._utils.utils import compute_cross_nn_distances
+from dadapy._utils.utils import compute_cross_nn_distances, cores
 from dadapy.kstar import KStar
-
-cores = multiprocessing.cpu_count()
 
 
 class DensityEstimation(KStar):

--- a/dadapy/feature_weighting.py
+++ b/dadapy/feature_weighting.py
@@ -19,7 +19,6 @@ The *feature_weighting* module contains the *FeatureWeighting* class.
 This class uses Differentiable Information Imbalance
 """
 
-import multiprocessing
 import time
 import warnings
 from functools import wraps
@@ -40,9 +39,8 @@ from dadapy._utils.differentiable_imbalance import (
     _return_full_rank_matrix,
     _return_optimal_lambda_from_distances,
 )
+from dadapy._utils.utils import cores
 from dadapy.base import Base
-
-cores = multiprocessing.cpu_count()
 
 
 # TODO: remove when this works with different maxk

--- a/dadapy/id_discrete.py
+++ b/dadapy/id_discrete.py
@@ -20,17 +20,14 @@ The different algorithms of intrinsic dimension estimation for discrete spaces
   are implemented as methods of this class.
 """
 
-import multiprocessing
-
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy.stats import ks_2samp as KS
 
 import dadapy._utils.discrete_functions as df
 from dadapy import plot as ddp
+from dadapy._utils.utils import cores
 from dadapy.base import Base
-
-cores = multiprocessing.cpu_count()
 
 
 class IdDiscrete(Base):

--- a/dadapy/id_estimation.py
+++ b/dadapy/id_estimation.py
@@ -21,7 +21,6 @@ The different algorithms of intrinsic dimension estimation are implemented as me
 
 import copy
 import math
-import multiprocessing
 import warnings
 from functools import partial
 
@@ -31,10 +30,8 @@ from sklearn.metrics import pairwise_distances_chunked
 
 from dadapy._utils import utils as ut
 from dadapy._utils.id_estimation import _binomial_model_validation as bmv
-from dadapy._utils.utils import compute_nn_distances
+from dadapy._utils.utils import compute_nn_distances, cores
 from dadapy.base import Base
-
-cores = multiprocessing.cpu_count()
 
 
 class IdEstimation(Base):

--- a/dadapy/kstar.py
+++ b/dadapy/kstar.py
@@ -19,16 +19,14 @@ The *kstar* module contains the *KStar* class.
 The computation of the optimal neighbourhood size (k*) is implemented in this class as the compute_kstar method.
 """
 
-import multiprocessing
 import time
 import warnings
 
 import numpy as np
 
 from dadapy._cython import cython_density as cd
+from dadapy._utils.utils import cores
 from dadapy.id_estimation import IdEstimation
-
-cores = multiprocessing.cpu_count()
 
 
 class KStar(IdEstimation):

--- a/dadapy/metric_comparisons.py
+++ b/dadapy/metric_comparisons.py
@@ -19,7 +19,6 @@ The *metric_comparisons* module contains the *MetricComparisons* class.
 Algorithms for comparing different spaces are implemented as methods of this class.
 """
 
-import multiprocessing
 import warnings
 from collections import Counter
 
@@ -33,10 +32,8 @@ from dadapy._utils.metric_comparisons import (
     _return_period_mixed,
     _return_period_present,
 )
-from dadapy._utils.utils import compute_nn_distances
+from dadapy._utils.utils import compute_nn_distances, cores
 from dadapy.base import Base
-
-cores = multiprocessing.cpu_count()
 
 
 class MetricComparisons(Base):

--- a/dadapy/neigh_graph.py
+++ b/dadapy/neigh_graph.py
@@ -19,16 +19,14 @@ The *neighbourhood_graph* module contains the *NeighGraph* class.
 It contains different methods and attributes which allow to exploit the structure of the directed neighbourhood graph.
 """
 
-import multiprocessing
 import time
 
 import numpy as np
 from scipy import sparse
 
 from dadapy._cython import cython_grads as cgr
+from dadapy._utils.utils import cores
 from dadapy.kstar import KStar
-
-cores = multiprocessing.cpu_count()
 
 
 class NeighGraph(KStar):


### PR DESCRIPTION
Fixes #145

I capped the maximum number of threads at `min(128, multiprocessing.cpu_count())` and fixed issue #145.

* `n_jobs` can be configured in the base class as a regular parameter (as before).
* If `n_jobs` is not specified, it defaults to `min(128, multiprocessing.cpu_count())`.
* Thread configuration is now centralized in a single module instead of being handled across multiple parts of the codebase.
